### PR TITLE
CORS 우회를 위해 API 요청 구조 변경

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -2,47 +2,33 @@
  * API 호출 관련 함수
  *
  * 서버와의 통신을 담당하며, 디바이스 등록/조회/삭제, 복습 URL 저장 등의 API를 제공한다.
+ * 모든 API 요청은 background.js를 통해 처리되어 CORS 문제를 우회한다.
  */
 
-import { CONFIG } from './config.js';
 import { ERROR_CODES } from './constants.js';
 import { ApiError, getErrorCodeFromStatus } from './errors.js';
 
 /**
- * API 요청 래퍼 (공통 에러 처리)
- * @param {string} url - 요청 URL
- * @param {Object} options - fetch 옵션
+ * Background Script로 API 요청 전송
+ * @param {Object} request - API 요청 정보
  * @returns {Promise<Object|null>} 응답 데이터
  * @throws {ApiError}
  */
-async function apiRequest(url, options = {}) {
-  let response;
+async function sendApiRequest(request) {
+  const response = await chrome.runtime.sendMessage({
+    type: 'API_REQUEST',
+    request
+  });
 
-  try {
-    response = await fetch(url, options);
-  } catch (error) {
-    throw new ApiError(ERROR_CODES.NETWORK_ERROR, error.message);
-  }
-
-  // 204 No Content인 경우 (DELETE 성공 등)
-  if (response.status === 204) {
-    return null;
-  }
-
-  let data;
-  try {
-    data = await response.json();
-  } catch (parseError) {
-    console.error('Failed to parse JSON response:', parseError);
-    data = { message: 'Invalid JSON response from server.' };
-  }
-
-  if (!response.ok) {
+  if (!response.success) {
+    if (response.isNetworkError) {
+      throw new ApiError(ERROR_CODES.NETWORK_ERROR, response.message);
+    }
     const errorCode = getErrorCodeFromStatus(response.status);
-    throw new ApiError(errorCode, data.message);
+    throw new ApiError(errorCode, response.message);
   }
 
-  return data;
+  return response.data;
 }
 
 /**
@@ -51,10 +37,10 @@ async function apiRequest(url, options = {}) {
  * @returns {Promise<Object>} { email, identifier }
  */
 export async function registerDevice(email) {
-  return await apiRequest(`${CONFIG.BASE_URL}/api/v1/members`, {
+  return await sendApiRequest({
+    endpoint: '/api/v1/members',
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ email })
+    body: { email }
   });
 }
 
@@ -65,8 +51,11 @@ export async function registerDevice(email) {
  * @returns {Promise<Object>} { email, devices }
  */
 export async function getDevices(email, identifier) {
-  const params = new URLSearchParams({ email, identifier });
-  return await apiRequest(`${CONFIG.BASE_URL}/api/v1/members?${params}`);
+  return await sendApiRequest({
+    endpoint: '/api/v1/members',
+    method: 'GET',
+    params: { email, identifier }
+  });
 }
 
 /**
@@ -76,14 +65,10 @@ export async function getDevices(email, identifier) {
  * @param {string} targetDeviceIdentifier - 삭제할 디바이스 식별자
  */
 export async function deleteDevice(email, deviceIdentifier, targetDeviceIdentifier) {
-  return await apiRequest(`${CONFIG.BASE_URL}/api/v1/device`, {
+  return await sendApiRequest({
+    endpoint: '/api/v1/device',
     method: 'DELETE',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      email,
-      deviceIdentifier,
-      targetDeviceIdentifier
-    })
+    body: { email, deviceIdentifier, targetDeviceIdentifier }
   });
 }
 
@@ -94,9 +79,9 @@ export async function deleteDevice(email, deviceIdentifier, targetDeviceIdentifi
  * @returns {Promise<Object>} { url, scheduledAts }
  */
 export async function saveReviewUrl(identifier, targetUrl) {
-  return await apiRequest(`${CONFIG.BASE_URL}/api/v1/reviews`, {
+  return await sendApiRequest({
+    endpoint: '/api/v1/reviews',
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ identifier, targetUrl })
+    body: { identifier, targetUrl }
   });
 }

--- a/src/background.js
+++ b/src/background.js
@@ -2,7 +2,10 @@
  * 백그라운드 서비스 워커
  *
  * 익스텐션 설치/업데이트 이벤트 처리 및 popup과의 메시지 통신을 담당한다.
+ * API 요청은 CORS 우회를 위해 이 서비스 워커에서 처리한다.
  */
+
+import { CONFIG } from './config.js';
 
 // ============================================
 // 익스텐션 설치/업데이트 이벤트
@@ -16,9 +19,63 @@ chrome.runtime.onInstalled.addListener((details) => {
 });
 
 // ============================================
-// 메시지 리스너 (popup.js와 통신용)
+// API 프록시 핸들러
+// ============================================
+async function handleApiRequest(request) {
+  const { endpoint, method = 'GET', body, params } = request;
+
+  let url = `${CONFIG.BASE_URL}${endpoint}`;
+  if (params) {
+    url += `?${new URLSearchParams(params)}`;
+  }
+
+  const options = {
+    method,
+    headers: { 'Content-Type': 'application/json' }
+  };
+
+  if (body) {
+    options.body = JSON.stringify(body);
+  }
+
+  try {
+    const response = await fetch(url, options);
+
+    // 204 No Content
+    if (response.status === 204) {
+      return { success: true, data: null };
+    }
+
+    let data;
+    try {
+      data = await response.json();
+    } catch (parseError) {
+      console.error('Failed to parse JSON response:', parseError);
+      data = { message: 'Invalid JSON response from server.' };
+    }
+
+    if (!response.ok) {
+      console.error('API request failed:', { url, status: response.status, data });
+      return { success: false, status: response.status, message: data.message };
+    }
+
+    return { success: true, data };
+  } catch (error) {
+    console.error('Network request failed:', { url, error });
+    return { success: false, status: 0, message: error.message, isNetworkError: true };
+  }
+}
+
+// ============================================
+// 메시지 리스너 (popup과 통신)
 // ============================================
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === 'API_REQUEST') {
+    handleApiRequest(message.request)
+      .then(sendResponse);
+    return true; // 비동기 응답을 위해 true 반환
+  }
+
   if (message.type === 'CHECK_AUTH') {
     sendResponse({ success: true });
   }


### PR DESCRIPTION
<!-- PR 템플릿 -->

## 🚀 작업 내용

API 요청을 popup에서 직접 호출하지 않고 background script를 경유하도록 변경했습니다.

```
[Popup] → sendMessage → [Background] → fetch → [Server]
```

**변경 사항:**
| 파일 | 내용 |
|------|------|
| `background.js` | API 프록시 핸들러 추가 |
| `api.js` | 직접 fetch → `chrome.runtime.sendMessage` 방식으로 변경 |

## 📸 이슈 번호

- close #17 

## ✍ 궁금한 점

- 추후에 웹 페이지도 구성하게 된다면 cors 설정도 고려해야 할 것 같다. 익스텐션은 왜 cors를 거치지 않도록 우회하는 방법을 많이 사용하는지?
