### PR TITLE
디바이스 인증 방식 헤더 마이그레이션 (Phase 1)

### DIFF
--- a/src/main/java/com/recyclestudy/common/annotation/AuthDevice.java
+++ b/src/main/java/com/recyclestudy/common/annotation/AuthDevice.java
@@ -1,0 +1,11 @@
+package com.recyclestudy.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthDevice {
+}

--- a/src/main/java/com/recyclestudy/common/config/WebMvcConfig.java
+++ b/src/main/java/com/recyclestudy/common/config/WebMvcConfig.java
@@ -1,0 +1,20 @@
+package com.recyclestudy.common.config;
+
+import com.recyclestudy.common.resolver.DeviceAuthArgumentResolver;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final DeviceAuthArgumentResolver deviceAuthArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(deviceAuthArgumentResolver);
+    }
+}

--- a/src/main/java/com/recyclestudy/common/resolver/DeviceAuthArgumentResolver.java
+++ b/src/main/java/com/recyclestudy/common/resolver/DeviceAuthArgumentResolver.java
@@ -1,0 +1,48 @@
+package com.recyclestudy.common.resolver;
+
+import com.recyclestudy.common.annotation.AuthDevice;
+import com.recyclestudy.exception.UnauthorizedException;
+import com.recyclestudy.member.domain.Device;
+import com.recyclestudy.member.domain.DeviceIdentifier;
+import com.recyclestudy.member.repository.DeviceRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class DeviceAuthArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final DeviceRepository deviceRepository;
+
+    @Override
+    public boolean supportsParameter(final MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthDevice.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+            final MethodParameter parameter,
+            final ModelAndViewContainer mavContainer,
+            final NativeWebRequest webRequest,
+            final WebDataBinderFactory binderFactory
+    ) {
+        final String headerIdentifier = Optional.ofNullable(webRequest.getHeader("X-device-Id"))
+                .orElseThrow(() -> new UnauthorizedException("디바이스 인증 헤더가 누락되었습니다"));
+
+        final DeviceIdentifier identifier = DeviceIdentifier.from(headerIdentifier);
+        final Device device = deviceRepository.findByIdentifier(identifier)
+                .orElseThrow(() -> new UnauthorizedException("유효하지 않은 디바이스입니다"));
+
+        if (!device.isActive()) {
+            throw new UnauthorizedException("인증되지 않은 디바이스입니다");
+        }
+
+        return identifier;
+    }
+}

--- a/src/main/java/com/recyclestudy/member/controller/DeviceController.java
+++ b/src/main/java/com/recyclestudy/member/controller/DeviceController.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -33,10 +34,22 @@ public class DeviceController {
 
     @DeleteMapping
     @ResponseBody
-    public ResponseEntity<Void> deleteDevice(@RequestBody final DeviceDeleteRequest request) {
-        final DeviceDeleteInput input = DeviceDeleteInput.from(request.email(), request.deviceIdentifier(),
+    public ResponseEntity<Void> deleteDevice(
+            @RequestHeader(value = "X-Device-Id", required = false) String headerIdentifier,
+            @RequestBody final DeviceDeleteRequest request
+    ) {
+        final String resolvedIdentifier = getResolvedIdentifier(request.deviceIdentifier(), headerIdentifier);
+
+        final DeviceDeleteInput input = DeviceDeleteInput.from(request.email(), resolvedIdentifier,
                 request.targetDeviceIdentifier());
         memberService.deleteDevice(input);
         return ResponseEntity.noContent().build();
+    }
+
+    private String getResolvedIdentifier(final String identifier, final String headerIdentifier) {
+        if (headerIdentifier == null) {
+            return identifier;
+        }
+        return headerIdentifier;
     }
 }

--- a/src/main/java/com/recyclestudy/member/controller/MemberController.java
+++ b/src/main/java/com/recyclestudy/member/controller/MemberController.java
@@ -15,6 +15,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -41,11 +42,21 @@ public class MemberController {
     @GetMapping
     public ResponseEntity<MemberFindResponse> findAllMemberDevices(
             @RequestParam(name = "email") final String email,
-            @RequestParam(name = "identifier") final String identifier
+            @RequestParam(name = "identifier", required = false) final String identifier,
+            @RequestHeader(value = "X-Device-Id", required = false) String headerIdentifier
     ) {
-        final MemberFindInput input = MemberFindInput.from(email, identifier);
+        final String resolvedIdentifier = getResolvedIdentifier(identifier, headerIdentifier);
+
+        final MemberFindInput input = MemberFindInput.from(email, resolvedIdentifier);
         final MemberFindOutput output = memberService.findAllMemberDevices(input);
         final MemberFindResponse response = MemberFindResponse.from(output);
         return ResponseEntity.ok(response);
+    }
+
+    private String getResolvedIdentifier(final String identifier, final String headerIdentifier) {
+        if (headerIdentifier == null) {
+            return identifier;
+        }
+        return headerIdentifier;
     }
 }

--- a/src/main/java/com/recyclestudy/review/controller/ReviewController.java
+++ b/src/main/java/com/recyclestudy/review/controller/ReviewController.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,10 +22,22 @@ public class ReviewController {
     private final ReviewService reviewService;
 
     @PostMapping
-    public ResponseEntity<ReviewSaveResponse> saveReview(@RequestBody ReviewSaveRequest request) {
-        final ReviewSaveInput input = request.toInput();
+    public ResponseEntity<ReviewSaveResponse> saveReview(
+            @RequestHeader(value = "X-Device-Id", required = false) String headerIdentifier,
+            @RequestBody ReviewSaveRequest request
+    ) {
+        final String resolvedIdentifier = getResolvedIdentifier(request.identifier(), headerIdentifier);
+
+        final ReviewSaveInput input = ReviewSaveInput.of(resolvedIdentifier, request.targetUrl());
         final ReviewSaveOutput output = reviewService.saveReview(input);
         ReviewSaveResponse response = ReviewSaveResponse.of(output.url(), output.scheduledAts());
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    private String getResolvedIdentifier(final String identifier, final String headerIdentifier) {
+        if (headerIdentifier == null) {
+            return identifier;
+        }
+        return headerIdentifier;
     }
 }

--- a/src/test/java/com/recyclestudy/member/controller/DeviceControllerTest.java
+++ b/src/test/java/com/recyclestudy/member/controller/DeviceControllerTest.java
@@ -545,4 +545,41 @@ class DeviceControllerTest extends APIBaseTest {
                 .statusCode(HttpStatus.BAD_REQUEST.value())
                 .body("message", equalTo("null이 될 수 없습니다: value"));
     }
+
+    @Test
+    @DisplayName("헤더로 디바이스 인증하여 삭제 시 204 응답을 반환한다")
+    void deleteDevice_WithHeader() {
+        // given
+        final String headerIdentifier = "device-id";
+        final DeviceDeleteRequest request = new DeviceDeleteRequest("test@test.com", null, "target-id");
+
+        doNothing().when(memberService).deleteDevice(any());
+
+        // when
+        // then
+        given(this.spec)
+                .filter(document(DEFAULT_REST_DOC_PATH,
+                        builder()
+                                .tag("Device")
+                                .summary("디바이스 삭제")
+                                .description("헤더로 디바이스 인증하여 삭제 시 204 응답을 반환한다")
+                                .requestHeaders(
+                                        headerWithName("X-Device-Id").description("디바이스 식별자")
+                                )
+                                .requestFields(
+                                        fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
+                                        fieldWithPath("identifier").type(JsonFieldType.STRING)
+                                                .description("디바이스 식별자 (deprecated, 헤더 사용 권장)").optional(),
+                                        fieldWithPath("targetIdentifier").type(JsonFieldType.STRING)
+                                                .description("삭제할 디바이스 식별자")
+                                )
+                ))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("X-Device-Id", headerIdentifier)
+                .body(request)
+                .when()
+                .delete("/api/v1/device")
+                .then()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+    }
 }

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -15,6 +15,7 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.H2Dialect
+    open-in-view: false
 
   mail:
     host: localhost


### PR DESCRIPTION
<!-- PR 템플릿 -->

## 🚀 작업 내용

- 디바이스 인증 정보(identifier)를 Body에서 `X-Device-Id` 헤더로 전달하는 방식 추가
- 마이그레이션 기간 동안 헤더 우선, Body fallback 처리
- Phase 3 적용을 위한 `@AuthDevice` ArgumentResolver 구현

### 변경 사항

- **컨트롤러**: `X-Device-Id` 헤더 수신 및 fallback 로직 추가
  - `ReviewController`, `DeviceController`, `MemberController`
- **ArgumentResolver**: `@AuthDevice` 애노테이션 + `DeviceAuthArgumentResolver` 구현
- **테스트**: 헤더 방식 테스트 코드 추가
- **Swagger**: 헤더 파라미터 문서화

## 📸 이슈 번호

- close #45 

## ✍ 궁금한 점

- ArgumentResolver에서 Body 접근이 어려워 마이그레이션 기간에는 컨트롤러에서 fallback 처리함. Phase 3에서 `@AuthDevice` 적용 예정.
