### PR TITLE
사용자 커스텀 복습 주기 관리 및 커스텀 주기 기반 리뷰 저장 기능 구현

### DIFF
--- a/src/main/java/com/recyclestudy/cycle/controller/CycleOptionController.java
+++ b/src/main/java/com/recyclestudy/cycle/controller/CycleOptionController.java
@@ -1,13 +1,20 @@
 package com.recyclestudy.cycle.controller;
 
 import com.recyclestudy.common.annotation.AuthDevice;
+import com.recyclestudy.cycle.controller.request.CycleOptionSaveRequest;
 import com.recyclestudy.cycle.controller.response.CycleOptionFindResponse;
+import com.recyclestudy.cycle.controller.response.CycleOptionSaveResponse;
 import com.recyclestudy.cycle.service.CycleOptionService;
+import com.recyclestudy.cycle.service.input.CycleOptionSaveInput;
 import com.recyclestudy.cycle.service.output.CycleOptionFindOutput;
+import com.recyclestudy.cycle.service.output.CycleOptionSaveOutput;
 import com.recyclestudy.member.domain.DeviceIdentifier;
+import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,5 +30,16 @@ public class CycleOptionController {
         CycleOptionFindOutput output = cycleOptionService.findAllCycleOptions(identifier);
         CycleOptionFindResponse response = CycleOptionFindResponse.from(output);
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping
+    public ResponseEntity<CycleOptionSaveResponse> saveCycleOption(
+            @AuthDevice final DeviceIdentifier identifier,
+            @RequestBody final CycleOptionSaveRequest request
+    ) {
+        final CycleOptionSaveInput input = request.toInput();
+        final CycleOptionSaveOutput output = cycleOptionService.saveCycleOption(identifier, input);
+        return ResponseEntity.created(URI.create("/api/v1/cycles/custom/" + output.id()))
+                .body(CycleOptionSaveResponse.from(output));
     }
 }

--- a/src/main/java/com/recyclestudy/cycle/controller/CycleOptionController.java
+++ b/src/main/java/com/recyclestudy/cycle/controller/CycleOptionController.java
@@ -2,18 +2,23 @@ package com.recyclestudy.cycle.controller;
 
 import com.recyclestudy.common.annotation.AuthDevice;
 import com.recyclestudy.cycle.controller.request.CycleOptionSaveRequest;
+import com.recyclestudy.cycle.controller.request.CycleOptionUpdateRequest;
 import com.recyclestudy.cycle.controller.response.CycleOptionFindResponse;
 import com.recyclestudy.cycle.controller.response.CycleOptionSaveResponse;
 import com.recyclestudy.cycle.service.CycleOptionService;
 import com.recyclestudy.cycle.service.input.CycleOptionSaveInput;
+import com.recyclestudy.cycle.service.input.CycleOptionUpdateInput;
 import com.recyclestudy.cycle.service.output.CycleOptionFindOutput;
 import com.recyclestudy.cycle.service.output.CycleOptionSaveOutput;
 import com.recyclestudy.member.domain.DeviceIdentifier;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -41,5 +46,25 @@ public class CycleOptionController {
         final CycleOptionSaveOutput output = cycleOptionService.saveCycleOption(identifier, input);
         return ResponseEntity.created(URI.create("/api/v1/cycles/custom/" + output.id()))
                 .body(CycleOptionSaveResponse.from(output));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<CycleOptionSaveResponse> updateCycleOption(
+            @AuthDevice final DeviceIdentifier identifier,
+            @PathVariable("id") final Long cycleOptionId,
+            @RequestBody final CycleOptionUpdateRequest request
+    ) {
+        final CycleOptionUpdateInput input = request.toInput();
+        final CycleOptionSaveOutput output = cycleOptionService.updateCycleOption(identifier, cycleOptionId, input);
+        return ResponseEntity.ok(CycleOptionSaveResponse.from(output));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteCycleOption(
+            @AuthDevice final DeviceIdentifier identifier,
+            @PathVariable("id") final Long cycleOptionId
+    ) {
+        cycleOptionService.deleteCycleOption(identifier, cycleOptionId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/recyclestudy/cycle/controller/CycleOptionController.java
+++ b/src/main/java/com/recyclestudy/cycle/controller/CycleOptionController.java
@@ -1,0 +1,27 @@
+package com.recyclestudy.cycle.controller;
+
+import com.recyclestudy.common.annotation.AuthDevice;
+import com.recyclestudy.cycle.controller.response.CycleOptionFindResponse;
+import com.recyclestudy.cycle.service.CycleOptionService;
+import com.recyclestudy.cycle.service.output.CycleOptionFindOutput;
+import com.recyclestudy.member.domain.DeviceIdentifier;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/cycles/custom")
+@RequiredArgsConstructor
+public class CycleOptionController {
+
+    private final CycleOptionService cycleOptionService;
+
+    @GetMapping
+    public ResponseEntity<CycleOptionFindResponse> findAllCycleOptions(@AuthDevice DeviceIdentifier identifier) {
+        CycleOptionFindOutput output = cycleOptionService.findAllCycleOptions(identifier);
+        CycleOptionFindResponse response = CycleOptionFindResponse.from(output);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/recyclestudy/cycle/controller/request/CycleOptionSaveRequest.java
+++ b/src/main/java/com/recyclestudy/cycle/controller/request/CycleOptionSaveRequest.java
@@ -1,11 +1,17 @@
 package com.recyclestudy.cycle.controller.request;
 
+import com.recyclestudy.cycle.domain.CycleOptionTitle;
 import com.recyclestudy.cycle.service.input.CycleOptionSaveInput;
+import com.recyclestudy.cycle.util.CycleDurationParser;
+import java.time.Duration;
 import java.util.List;
 
 public record CycleOptionSaveRequest(String title, List<String> durations) {
 
     public CycleOptionSaveInput toInput() {
-        return CycleOptionSaveInput.of(title, durations);
+        final CycleOptionTitle cycleOptionTitle = CycleOptionTitle.from(title);
+        final List<Duration> cycleOptionDurations = CycleDurationParser.parseList(durations);
+
+        return new CycleOptionSaveInput(cycleOptionTitle, cycleOptionDurations);
     }
 }

--- a/src/main/java/com/recyclestudy/cycle/controller/request/CycleOptionSaveRequest.java
+++ b/src/main/java/com/recyclestudy/cycle/controller/request/CycleOptionSaveRequest.java
@@ -1,0 +1,11 @@
+package com.recyclestudy.cycle.controller.request;
+
+import com.recyclestudy.cycle.service.input.CycleOptionSaveInput;
+import java.util.List;
+
+public record CycleOptionSaveRequest(String title, List<String> durations) {
+
+    public CycleOptionSaveInput toInput() {
+        return CycleOptionSaveInput.of(title, durations);
+    }
+}

--- a/src/main/java/com/recyclestudy/cycle/controller/request/CycleOptionUpdateRequest.java
+++ b/src/main/java/com/recyclestudy/cycle/controller/request/CycleOptionUpdateRequest.java
@@ -1,11 +1,17 @@
 package com.recyclestudy.cycle.controller.request;
 
+import com.recyclestudy.cycle.domain.CycleOptionTitle;
 import com.recyclestudy.cycle.service.input.CycleOptionUpdateInput;
+import com.recyclestudy.cycle.util.CycleDurationParser;
+import java.time.Duration;
 import java.util.List;
 
 public record CycleOptionUpdateRequest(String title, List<String> durations) {
 
     public CycleOptionUpdateInput toInput() {
-        return CycleOptionUpdateInput.of(title, durations);
+        final CycleOptionTitle cycleOptionTitle = CycleOptionTitle.from(title);
+        final List<Duration> cycleOptionDurations = CycleDurationParser.parseList(durations);
+
+        return new CycleOptionUpdateInput(cycleOptionTitle, cycleOptionDurations);
     }
 }

--- a/src/main/java/com/recyclestudy/cycle/controller/request/CycleOptionUpdateRequest.java
+++ b/src/main/java/com/recyclestudy/cycle/controller/request/CycleOptionUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.recyclestudy.cycle.controller.request;
+
+import com.recyclestudy.cycle.service.input.CycleOptionUpdateInput;
+import java.util.List;
+
+public record CycleOptionUpdateRequest(String title, List<String> durations) {
+
+    public CycleOptionUpdateInput toInput() {
+        return CycleOptionUpdateInput.of(title, durations);
+    }
+}

--- a/src/main/java/com/recyclestudy/cycle/controller/response/CycleOptionFindResponse.java
+++ b/src/main/java/com/recyclestudy/cycle/controller/response/CycleOptionFindResponse.java
@@ -1,0 +1,23 @@
+package com.recyclestudy.cycle.controller.response;
+
+import com.recyclestudy.cycle.service.output.CycleOptionFindOutput;
+import java.util.List;
+
+public record CycleOptionFindResponse(List<CycleOptionElement> options) {
+
+    public static CycleOptionFindResponse from(final CycleOptionFindOutput output) {
+        final List<CycleOptionElement> optionElements = output.options().stream()
+                .map(option -> new CycleOptionElement(
+                        option.id(),
+                        option.title().getValue(),
+                        option.durations().stream()
+                                .map(Object::toString)
+                                .toList()
+                ))
+                .toList();
+        return new CycleOptionFindResponse(optionElements);
+    }
+
+    public record CycleOptionElement(Long id, String title, List<String> durations) {
+    }
+}

--- a/src/main/java/com/recyclestudy/cycle/controller/response/CycleOptionFindResponse.java
+++ b/src/main/java/com/recyclestudy/cycle/controller/response/CycleOptionFindResponse.java
@@ -32,9 +32,9 @@ public record CycleOptionFindResponse(
         return new CycleOptionFindResponse(defaultElements, customElements);
     }
 
-    public record DefaultOptionElement(String code, String title, List<String> durations) {
+    private record DefaultOptionElement(String code, String title, List<String> durations) {
     }
 
-    public record CustomOptionElement(Long id, String title, List<String> durations) {
+    private record CustomOptionElement(Long id, String title, List<String> durations) {
     }
 }

--- a/src/main/java/com/recyclestudy/cycle/controller/response/CycleOptionFindResponse.java
+++ b/src/main/java/com/recyclestudy/cycle/controller/response/CycleOptionFindResponse.java
@@ -3,21 +3,38 @@ package com.recyclestudy.cycle.controller.response;
 import com.recyclestudy.cycle.service.output.CycleOptionFindOutput;
 import java.util.List;
 
-public record CycleOptionFindResponse(List<CycleOptionElement> options) {
+public record CycleOptionFindResponse(
+        List<DefaultOptionElement> defaultOptions,
+        List<CustomOptionElement> customOptions
+) {
 
     public static CycleOptionFindResponse from(final CycleOptionFindOutput output) {
-        final List<CycleOptionElement> optionElements = output.options().stream()
-                .map(option -> new CycleOptionElement(
-                        option.id(),
-                        option.title().getValue(),
+        final List<DefaultOptionElement> defaultElements = output.defaultOptions().stream()
+                .map(option -> new DefaultOptionElement(
+                        option.code(),
+                        option.title(),
                         option.durations().stream()
                                 .map(Object::toString)
                                 .toList()
                 ))
                 .toList();
-        return new CycleOptionFindResponse(optionElements);
+
+        final List<CustomOptionElement> customElements = output.customOptions().stream()
+                .map(option -> new CustomOptionElement(
+                        option.id(),
+                        option.title(),
+                        option.durations().stream()
+                                .map(Object::toString)
+                                .toList()
+                ))
+                .toList();
+
+        return new CycleOptionFindResponse(defaultElements, customElements);
     }
 
-    public record CycleOptionElement(Long id, String title, List<String> durations) {
+    public record DefaultOptionElement(String code, String title, List<String> durations) {
+    }
+
+    public record CustomOptionElement(Long id, String title, List<String> durations) {
     }
 }

--- a/src/main/java/com/recyclestudy/cycle/controller/response/CycleOptionSaveResponse.java
+++ b/src/main/java/com/recyclestudy/cycle/controller/response/CycleOptionSaveResponse.java
@@ -1,0 +1,18 @@
+package com.recyclestudy.cycle.controller.response;
+
+import com.recyclestudy.cycle.service.output.CycleOptionSaveOutput;
+import java.util.List;
+
+public record CycleOptionSaveResponse(Long id, String title, List<String> durations) {
+
+    public static CycleOptionSaveResponse from(final CycleOptionSaveOutput output) {
+        return new CycleOptionSaveResponse(
+                output.id(),
+                output.title().getValue(),
+                output.durations().stream()
+                        .map(Object::toString)
+                        .toList()
+        );
+
+    }
+}

--- a/src/main/java/com/recyclestudy/cycle/controller/response/CycleOptionSaveResponse.java
+++ b/src/main/java/com/recyclestudy/cycle/controller/response/CycleOptionSaveResponse.java
@@ -13,6 +13,5 @@ public record CycleOptionSaveResponse(Long id, String title, List<String> durati
                         .map(Object::toString)
                         .toList()
         );
-
     }
 }

--- a/src/main/java/com/recyclestudy/cycle/domain/CycleDurations.java
+++ b/src/main/java/com/recyclestudy/cycle/domain/CycleDurations.java
@@ -1,0 +1,71 @@
+package com.recyclestudy.cycle.domain;
+
+import com.recyclestudy.exception.BadRequestException;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.OneToMany;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Embeddable
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
+@EqualsAndHashCode
+public class CycleDurations {
+
+    private static final Duration MIN_CYCLE_TERM = Duration.ofMinutes(10);
+    private static final Duration MAX_CYCLE_TERM = Duration.ofDays(365);
+
+    @OneToMany(mappedBy = "id.cycleOption", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CycleOptionDuration> values = new ArrayList<>();
+
+    public static CycleDurations from(final List<CycleOptionDuration> values) {
+        validate(values);
+        return new CycleDurations(values);
+    }
+
+    public void replace(final List<CycleOptionDuration> newOptions) {
+        validate(newOptions);
+        this.values.clear();
+        this.values.addAll(newOptions);
+    }
+
+    public List<CycleOptionDuration> getValues() {
+        return Collections.unmodifiableList(values);
+    }
+
+    private static void validate(final List<CycleOptionDuration> cycleOptionDurations) {
+        final List<Duration> durations = cycleOptionDurations.stream()
+                .map(CycleOptionDuration::getDuration)
+                .toList();
+
+        if (durations.isEmpty()) {
+            throw new BadRequestException("주기는 최소 1개 이상이어야 합니다.");
+        }
+
+        final boolean allTenMinutes = durations.stream()
+                .allMatch(duration -> !duration.isNegative() &&
+                        !duration.isZero() &&
+                        duration.toMinutes() % MIN_CYCLE_TERM.toMinutes() == 0);
+        if (!allTenMinutes) {
+            throw new BadRequestException("주기는 10분 단위여야 합니다.");
+        }
+
+        if (durations.getFirst().compareTo(MIN_CYCLE_TERM) < 0) {
+            throw new BadRequestException("첫 번째 주기는 최소 10분 이상이어야 합니다.");
+        }
+
+        final Duration lastDuration = durations.getLast();
+        if (lastDuration.compareTo(MAX_CYCLE_TERM) > 0) {
+            throw new BadRequestException("주기는 최대 1년 이내여야 합니다.");
+        }
+    }
+}

--- a/src/main/java/com/recyclestudy/cycle/domain/CycleDurations.java
+++ b/src/main/java/com/recyclestudy/cycle/domain/CycleDurations.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Embeddable
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
@@ -28,18 +28,10 @@ public class CycleDurations {
     private List<CycleOptionDuration> values = new ArrayList<>();
 
     public static CycleDurations from(final List<CycleOptionDuration> values) {
-        validate(values);
-        return new CycleDurations(values);
-    }
-
-    public void replace(final List<CycleOptionDuration> newOptions) {
-        validate(newOptions);
-        this.values.clear();
-        this.values.addAll(newOptions);
-    }
-
-    public List<CycleOptionDuration> getValues() {
-        return Collections.unmodifiableList(values);
+        final List<CycleOptionDuration> sorted = new ArrayList<>(values);
+        Collections.sort(sorted);
+        validate(sorted);
+        return new CycleDurations(sorted);
     }
 
     private static void validate(final List<CycleOptionDuration> cycleOptionDurations) {
@@ -47,10 +39,12 @@ public class CycleDurations {
                 .map(CycleOptionDuration::getDuration)
                 .toList();
 
-        if (durations.isEmpty()) {
-            throw new BadRequestException("주기는 최소 1개 이상이어야 합니다.");
-        }
+        checkEmpty(durations);
+        checkDistinct(durations);
+        checkDurationTerm(durations);
+    }
 
+    private static void checkDurationTerm(final List<Duration> durations) {
         final boolean allTenMinutes = durations.stream()
                 .allMatch(duration -> !duration.isNegative() &&
                         !duration.isZero() &&
@@ -67,5 +61,32 @@ public class CycleDurations {
         if (lastDuration.compareTo(MAX_CYCLE_TERM) > 0) {
             throw new BadRequestException("주기는 최대 1년 이내여야 합니다.");
         }
+    }
+
+    private static void checkEmpty(final List<Duration> durations) {
+        if (durations.isEmpty()) {
+            throw new BadRequestException("주기는 최소 1개 이상이어야 합니다.");
+        }
+    }
+
+    private static void checkDistinct(final List<Duration> durations) {
+        final long distinctCount = durations.stream()
+                .distinct()
+                .count();
+        if (durations.size() != distinctCount) {
+            throw new BadRequestException("중복된 주기가 존재합니다.");
+        }
+    }
+
+    public void replace(final List<CycleOptionDuration> newOptions) {
+        final List<CycleOptionDuration> sorted = new ArrayList<>(newOptions);
+        Collections.sort(sorted);
+        validate(sorted);
+        this.values.clear();
+        this.values.addAll(sorted);
+    }
+
+    public List<CycleOptionDuration> getValues() {
+        return Collections.unmodifiableList(values);
     }
 }

--- a/src/main/java/com/recyclestudy/cycle/domain/CycleOption.java
+++ b/src/main/java/com/recyclestudy/cycle/domain/CycleOption.java
@@ -56,6 +56,10 @@ public class CycleOption extends BaseEntity {
         return new CycleOption(member, title, optionType, new ArrayList<>());
     }
 
+    public void addDurations(final List<CycleOptionDuration> newDurations) {
+        this.durations.addAll(newDurations);
+    }
+
     private static void validateNotNull(
             final Member member,
             final CycleOptionTitle title,

--- a/src/main/java/com/recyclestudy/cycle/domain/CycleOption.java
+++ b/src/main/java/com/recyclestudy/cycle/domain/CycleOption.java
@@ -1,0 +1,70 @@
+package com.recyclestudy.cycle.domain;
+
+import com.recyclestudy.common.BaseEntity;
+import com.recyclestudy.common.NullValidator;
+import com.recyclestudy.member.domain.Member;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldNameConstants;
+
+@Entity
+@Table(name = "cycle_option")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@FieldNameConstants(level = AccessLevel.PRIVATE)
+@Getter
+public class CycleOption extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Embedded
+    @AttributeOverride(name = "value", column = @Column(name = "title", nullable = false))
+    private CycleOptionTitle title;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "option_type", nullable = false)
+    private OptionType optionType;
+
+    @OneToMany(mappedBy = "id.cycleOption", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Column(name = "durations", nullable = false)
+    private List<CycleOptionDuration> durations;
+
+    public static CycleOption withoutId(
+            final Member member,
+            final CycleOptionTitle title,
+            final OptionType optionType
+    ) {
+        validateNotNull(member, title, optionType);
+        return new CycleOption(member, title, optionType, new ArrayList<>());
+    }
+
+    private static void validateNotNull(
+            final Member member,
+            final CycleOptionTitle title,
+            final OptionType optionType
+    ) {
+        NullValidator.builder()
+                .add(Fields.member, member)
+                .add(Fields.title, title)
+                .add(Fields.optionType, optionType)
+                .validate();
+    }
+}

--- a/src/main/java/com/recyclestudy/cycle/domain/CycleOption.java
+++ b/src/main/java/com/recyclestudy/cycle/domain/CycleOption.java
@@ -4,7 +4,6 @@ import com.recyclestudy.common.BaseEntity;
 import com.recyclestudy.common.NullValidator;
 import com.recyclestudy.member.domain.Member;
 import jakarta.persistence.AttributeOverride;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -13,12 +12,10 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import java.util.ArrayList;
+import java.time.Duration;
 import java.util.List;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldNameConstants;
@@ -26,7 +23,6 @@ import lombok.experimental.FieldNameConstants;
 @Entity
 @Table(name = "cycle_option")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @FieldNameConstants(level = AccessLevel.PRIVATE)
 @Getter
 public class CycleOption extends BaseEntity {
@@ -43,32 +39,66 @@ public class CycleOption extends BaseEntity {
     @Column(name = "option_type", nullable = false)
     private OptionType optionType;
 
-    @OneToMany(mappedBy = "id.cycleOption", cascade = CascadeType.ALL, orphanRemoval = true)
-    @Column(name = "durations", nullable = false)
-    private List<CycleOptionDuration> durations;
+    @Embedded
+    private CycleDurations durations;
 
-    public static CycleOption withoutId(
+    private CycleOption(
             final Member member,
             final CycleOptionTitle title,
             final OptionType optionType
     ) {
-        validateNotNull(member, title, optionType);
-        return new CycleOption(member, title, optionType, new ArrayList<>());
+        this.member = member;
+        this.title = title;
+        this.optionType = optionType;
     }
 
-    public void addDurations(final List<CycleOptionDuration> newDurations) {
-        this.durations.addAll(newDurations);
+    public static CycleOption withoutId(
+            final Member member,
+            final CycleOptionTitle title,
+            final OptionType optionType,
+            final List<Duration> durations
+    ) {
+        validateNotNull(member, title, optionType, durations);
+
+        final CycleOption option = new CycleOption(member, title, optionType);
+
+        final List<CycleOptionDuration> cycleOptionDurations = durations.stream()
+                .map(duration -> CycleOptionDuration.of(option, duration))
+                .toList();
+        option.durations = new CycleDurations(cycleOptionDurations);
+
+        return option;
+    }
+
+    public void update(final CycleOptionTitle title, final List<Duration> newDurationValues) {
+        validateNotNull(member, title, optionType, newDurationValues);
+        this.title = title;
+
+        final List<CycleOptionDuration> newDurations = newDurationValues.stream()
+                .map(duration -> CycleOptionDuration.of(this, duration))
+                .toList();
+        this.durations.replace(newDurations);
+    }
+
+    public boolean isOwner(final Member member) {
+        return this.member.getId().equals(member.getId());
+    }
+
+    public List<CycleOptionDuration> getDurations() {
+        return durations.getValues();
     }
 
     private static void validateNotNull(
             final Member member,
             final CycleOptionTitle title,
-            final OptionType optionType
+            final OptionType optionType,
+            final List<Duration> durations
     ) {
         NullValidator.builder()
                 .add(Fields.member, member)
                 .add(Fields.title, title)
                 .add(Fields.optionType, optionType)
+                .add(Fields.durations, durations)
                 .validate();
     }
 }

--- a/src/main/java/com/recyclestudy/cycle/domain/CycleOption.java
+++ b/src/main/java/com/recyclestudy/cycle/domain/CycleOption.java
@@ -7,8 +7,6 @@ import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -35,43 +33,45 @@ public class CycleOption extends BaseEntity {
     @AttributeOverride(name = "value", column = @Column(name = "title", nullable = false))
     private CycleOptionTitle title;
 
-    @Enumerated(value = EnumType.STRING)
-    @Column(name = "option_type", nullable = false)
-    private OptionType optionType;
-
     @Embedded
     private CycleDurations durations;
 
-    private CycleOption(
-            final Member member,
-            final CycleOptionTitle title,
-            final OptionType optionType
-    ) {
+    private CycleOption(final Member member, final CycleOptionTitle title) {
         this.member = member;
         this.title = title;
-        this.optionType = optionType;
     }
 
     public static CycleOption withoutId(
             final Member member,
             final CycleOptionTitle title,
-            final OptionType optionType,
             final List<Duration> durations
     ) {
-        validateNotNull(member, title, optionType, durations);
+        validateNotNull(member, title, durations);
 
-        final CycleOption option = new CycleOption(member, title, optionType);
+        final CycleOption option = new CycleOption(member, title);
 
         final List<CycleOptionDuration> cycleOptionDurations = durations.stream()
                 .map(duration -> CycleOptionDuration.of(option, duration))
                 .toList();
-        option.durations = new CycleDurations(cycleOptionDurations);
+        option.durations = CycleDurations.from(cycleOptionDurations);
 
         return option;
     }
 
+    private static void validateNotNull(
+            final Member member,
+            final CycleOptionTitle title,
+            final List<Duration> durations
+    ) {
+        NullValidator.builder()
+                .add(Fields.member, member)
+                .add(Fields.title, title)
+                .add(Fields.durations, durations)
+                .validate();
+    }
+
     public void update(final CycleOptionTitle title, final List<Duration> newDurationValues) {
-        validateNotNull(member, title, optionType, newDurationValues);
+        validateNotNull(member, title, newDurationValues);
         this.title = title;
 
         final List<CycleOptionDuration> newDurations = newDurationValues.stream()
@@ -86,19 +86,5 @@ public class CycleOption extends BaseEntity {
 
     public List<CycleOptionDuration> getDurations() {
         return durations.getValues();
-    }
-
-    private static void validateNotNull(
-            final Member member,
-            final CycleOptionTitle title,
-            final OptionType optionType,
-            final List<Duration> durations
-    ) {
-        NullValidator.builder()
-                .add(Fields.member, member)
-                .add(Fields.title, title)
-                .add(Fields.optionType, optionType)
-                .add(Fields.durations, durations)
-                .validate();
     }
 }

--- a/src/main/java/com/recyclestudy/cycle/domain/CycleOptionDuration.java
+++ b/src/main/java/com/recyclestudy/cycle/domain/CycleOptionDuration.java
@@ -2,6 +2,7 @@ package com.recyclestudy.cycle.domain;
 
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
 import java.time.Duration;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -9,10 +10,13 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import lombok.experimental.FieldNameConstants;
 
 @Entity
+@Table(name = "cycle_option_duration")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@FieldNameConstants(level = AccessLevel.PRIVATE)
 @Getter
 @ToString
 @EqualsAndHashCode
@@ -23,5 +27,9 @@ public class CycleOptionDuration {
 
     public static CycleOptionDuration of(final CycleOption cycleOption, final Duration duration) {
         return new CycleOptionDuration(CycleOptionDurationId.of(cycleOption, duration));
+    }
+
+    public Duration getDuration() {
+        return this.getId().getDuration();
     }
 }

--- a/src/main/java/com/recyclestudy/cycle/domain/CycleOptionDuration.java
+++ b/src/main/java/com/recyclestudy/cycle/domain/CycleOptionDuration.java
@@ -20,7 +20,7 @@ import lombok.experimental.FieldNameConstants;
 @Getter
 @ToString
 @EqualsAndHashCode
-public class CycleOptionDuration {
+public class CycleOptionDuration implements Comparable<CycleOptionDuration> {
 
     @EmbeddedId
     private CycleOptionDurationId id;
@@ -31,5 +31,10 @@ public class CycleOptionDuration {
 
     public Duration getDuration() {
         return this.getId().getDuration();
+    }
+
+    @Override
+    public int compareTo(final CycleOptionDuration o) {
+        return this.id.getDuration().compareTo(o.getDuration());
     }
 }

--- a/src/main/java/com/recyclestudy/cycle/domain/CycleOptionDuration.java
+++ b/src/main/java/com/recyclestudy/cycle/domain/CycleOptionDuration.java
@@ -1,0 +1,27 @@
+package com.recyclestudy.cycle.domain;
+
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import java.time.Duration;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@ToString
+@EqualsAndHashCode
+public class CycleOptionDuration {
+
+    @EmbeddedId
+    private CycleOptionDurationId id;
+
+    public static CycleOptionDuration of(final CycleOption cycleOption, final Duration duration) {
+        return new CycleOptionDuration(CycleOptionDurationId.of(cycleOption, duration));
+    }
+}

--- a/src/main/java/com/recyclestudy/cycle/domain/CycleOptionDurationId.java
+++ b/src/main/java/com/recyclestudy/cycle/domain/CycleOptionDurationId.java
@@ -43,4 +43,3 @@ public class CycleOptionDurationId {
                 .validate();
     }
 }
-

--- a/src/main/java/com/recyclestudy/cycle/domain/CycleOptionDurationId.java
+++ b/src/main/java/com/recyclestudy/cycle/domain/CycleOptionDurationId.java
@@ -1,0 +1,46 @@
+package com.recyclestudy.cycle.domain;
+
+import com.recyclestudy.common.NullValidator;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.Duration;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.FieldNameConstants;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@FieldNameConstants(level = AccessLevel.PRIVATE)
+@Getter
+@ToString
+@EqualsAndHashCode
+public class CycleOptionDurationId {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cycle_option_id", nullable = false)
+    private CycleOption cycleOption;
+
+    @Column(name = "duration", nullable = false, columnDefinition = "bigint")
+    private Duration duration;
+
+    public static CycleOptionDurationId of(final CycleOption cycleOption, final Duration duration) {
+        validateNotNull(cycleOption, duration);
+        return new CycleOptionDurationId(cycleOption, duration);
+    }
+
+    private static void validateNotNull(final CycleOption cycleOption, final Duration duration) {
+        NullValidator.builder()
+                .add(Fields.cycleOption, cycleOption)
+                .add(Fields.duration, duration)
+                .validate();
+    }
+}
+

--- a/src/main/java/com/recyclestudy/cycle/domain/CycleOptionTitle.java
+++ b/src/main/java/com/recyclestudy/cycle/domain/CycleOptionTitle.java
@@ -1,0 +1,34 @@
+package com.recyclestudy.cycle.domain;
+
+import com.recyclestudy.common.NullValidator;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.FieldNameConstants;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@FieldNameConstants(level = AccessLevel.PRIVATE)
+@Getter
+@ToString
+@EqualsAndHashCode
+public class CycleOptionTitle {
+
+    private String value;
+
+    public static CycleOptionTitle from(final String value) {
+        validateNotNull(value);
+        return new CycleOptionTitle(value);
+    }
+
+    private static void validateNotNull(final String value) {
+        NullValidator.builder()
+                .add(Fields.value, value)
+                .validate();
+    }
+}

--- a/src/main/java/com/recyclestudy/cycle/domain/CycleOptionTitle.java
+++ b/src/main/java/com/recyclestudy/cycle/domain/CycleOptionTitle.java
@@ -1,6 +1,7 @@
 package com.recyclestudy.cycle.domain;
 
 import com.recyclestudy.common.NullValidator;
+import com.recyclestudy.exception.BadRequestException;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -19,10 +20,16 @@ import lombok.experimental.FieldNameConstants;
 @EqualsAndHashCode
 public class CycleOptionTitle {
 
+    private static final int MAX_LENGTH = 30;
+
     private String value;
 
     public static CycleOptionTitle from(final String value) {
         validateNotNull(value);
+        if (value.isBlank() || value.trim().length() > MAX_LENGTH) {
+            throw new BadRequestException("유효하지 않은 제목의 길이입니다.(1 이상 30 이하)");
+        }
+
         return new CycleOptionTitle(value);
     }
 

--- a/src/main/java/com/recyclestudy/cycle/domain/DefaultCycleOption.java
+++ b/src/main/java/com/recyclestudy/cycle/domain/DefaultCycleOption.java
@@ -1,0 +1,27 @@
+package com.recyclestudy.cycle.domain;
+
+import java.time.Duration;
+import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum DefaultCycleOption {
+
+    EBBINGHAUS("에빙하우스 망각곡선", List.of(
+            Duration.ofMinutes(10),
+            Duration.ofHours(1),
+            Duration.ofDays(1),
+            Duration.ofDays(7),
+            Duration.ofDays(30)
+    )),
+    ;
+
+    private final String title;
+    private final List<Duration> durations;
+
+    public static List<DefaultCycleOption> getAll() {
+        return List.of(values());
+    }
+}

--- a/src/main/java/com/recyclestudy/cycle/domain/OptionType.java
+++ b/src/main/java/com/recyclestudy/cycle/domain/OptionType.java
@@ -1,7 +1,0 @@
-package com.recyclestudy.cycle.domain;
-
-public enum OptionType {
-    DEFAULT,
-    CUSTOM,
-    ;
-}

--- a/src/main/java/com/recyclestudy/cycle/domain/OptionType.java
+++ b/src/main/java/com/recyclestudy/cycle/domain/OptionType.java
@@ -1,0 +1,7 @@
+package com.recyclestudy.cycle.domain;
+
+public enum OptionType {
+    DEFAULT,
+    CUSTOM,
+    ;
+}

--- a/src/main/java/com/recyclestudy/cycle/domain/selection/CustomCycleSelection.java
+++ b/src/main/java/com/recyclestudy/cycle/domain/selection/CustomCycleSelection.java
@@ -1,0 +1,16 @@
+package com.recyclestudy.cycle.domain.selection;
+
+import com.recyclestudy.exception.BadRequestException;
+
+public record CustomCycleSelection(Long id) implements CycleSelection {
+
+    public CustomCycleSelection {
+        validateId(id);
+    }
+
+    private static void validateId(final Long id) {
+        if (id == null || id <= 0) {
+            throw new BadRequestException("유효하지 않은 커스텀 주기 ID입니다: " + id);
+        }
+    }
+}

--- a/src/main/java/com/recyclestudy/cycle/domain/selection/CycleSelection.java
+++ b/src/main/java/com/recyclestudy/cycle/domain/selection/CycleSelection.java
@@ -1,0 +1,12 @@
+package com.recyclestudy.cycle.domain.selection;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = DefaultCycleSelection.class, name = "DEFAULT"),
+        @JsonSubTypes.Type(value = CustomCycleSelection.class, name = "CUSTOM")
+})
+public sealed interface CycleSelection permits DefaultCycleSelection, CustomCycleSelection {
+}

--- a/src/main/java/com/recyclestudy/cycle/domain/selection/DefaultCycleSelection.java
+++ b/src/main/java/com/recyclestudy/cycle/domain/selection/DefaultCycleSelection.java
@@ -1,0 +1,19 @@
+package com.recyclestudy.cycle.domain.selection;
+
+import com.recyclestudy.cycle.domain.DefaultCycleOption;
+import com.recyclestudy.exception.BadRequestException;
+
+public record DefaultCycleSelection(String code) implements CycleSelection {
+
+    public DefaultCycleSelection {
+        validateCode(code);
+    }
+
+    private static void validateCode(final String code) {
+        try {
+            DefaultCycleOption.valueOf(code);
+        } catch (final IllegalArgumentException e) {
+            throw new BadRequestException("존재하지 않는 기본 주기입니다: " + code);
+        }
+    }
+}

--- a/src/main/java/com/recyclestudy/cycle/repository/CycleOptionRepository.java
+++ b/src/main/java/com/recyclestudy/cycle/repository/CycleOptionRepository.java
@@ -3,6 +3,7 @@ package com.recyclestudy.cycle.repository;
 import com.recyclestudy.cycle.domain.CycleOption;
 import com.recyclestudy.member.domain.Member;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,11 +11,21 @@ import org.springframework.data.repository.query.Param;
 public interface CycleOptionRepository extends JpaRepository<CycleOption, Long> {
 
     @Query("""
-                select co
-                from CycleOption co
-                join fetch co.member m
-                left join fetch co.durations.values
-                where m = :member
+            select co
+            from CycleOption co
+            join fetch co.member m
+            join fetch co.durations.values
+            where m = :member
             """)
     List<CycleOption> findAllByMember(@Param("member") Member member);
+
+    @Query("""
+            select co
+            from CycleOption co
+            join fetch co.durations.values
+            WHERE co.id = :id
+            """)
+    Optional<CycleOption> findByIdWithDurations(@Param("id") Long id);
+
+    long countByMember(Member member);
 }

--- a/src/main/java/com/recyclestudy/cycle/repository/CycleOptionRepository.java
+++ b/src/main/java/com/recyclestudy/cycle/repository/CycleOptionRepository.java
@@ -13,6 +13,7 @@ public interface CycleOptionRepository extends JpaRepository<CycleOption, Long> 
                 select co
                 from CycleOption co
                 join fetch co.member m
+                left join fetch co.durations.values
                 where m = :member
             """)
     List<CycleOption> findAllByMember(@Param("member") Member member);

--- a/src/main/java/com/recyclestudy/cycle/repository/CycleOptionRepository.java
+++ b/src/main/java/com/recyclestudy/cycle/repository/CycleOptionRepository.java
@@ -1,0 +1,19 @@
+package com.recyclestudy.cycle.repository;
+
+import com.recyclestudy.cycle.domain.CycleOption;
+import com.recyclestudy.member.domain.Member;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface CycleOptionRepository extends JpaRepository<CycleOption, Long> {
+
+    @Query("""
+                select co
+                from CycleOption co
+                join fetch co.member m
+                where m = :member
+            """)
+    List<CycleOption> findAllByMember(@Param("member") Member member);
+}

--- a/src/main/java/com/recyclestudy/cycle/service/CycleOptionService.java
+++ b/src/main/java/com/recyclestudy/cycle/service/CycleOptionService.java
@@ -1,18 +1,19 @@
 package com.recyclestudy.cycle.service;
 
 import com.recyclestudy.cycle.domain.CycleOption;
-import com.recyclestudy.cycle.domain.CycleOptionDuration;
 import com.recyclestudy.cycle.domain.OptionType;
 import com.recyclestudy.cycle.repository.CycleOptionRepository;
 import com.recyclestudy.cycle.service.input.CycleOptionSaveInput;
+import com.recyclestudy.cycle.service.input.CycleOptionUpdateInput;
 import com.recyclestudy.cycle.service.output.CycleOptionFindOutput;
 import com.recyclestudy.cycle.service.output.CycleOptionSaveOutput;
 import com.recyclestudy.exception.BadRequestException;
+import com.recyclestudy.exception.ForbiddenException;
+import com.recyclestudy.exception.NotFoundException;
 import com.recyclestudy.exception.UnauthorizedException;
 import com.recyclestudy.member.domain.DeviceIdentifier;
 import com.recyclestudy.member.domain.Member;
 import com.recyclestudy.member.repository.MemberRepository;
-import java.time.Duration;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -39,17 +40,50 @@ public class CycleOptionService {
                 .orElseThrow(() -> new UnauthorizedException("유효하지 않은 디바이스입니다"));
 
         validateCycleOptionCount(member);
-        validateDurations(input.durations());
 
-        final CycleOption cycleOption = CycleOption.withoutId(member, input.title(), OptionType.CUSTOM);
-        final List<CycleOptionDuration> durations = input.durations().stream()
-                .map(duration -> CycleOptionDuration.of(cycleOption, duration))
-                .toList();
-
-        cycleOption.addDurations(durations);
+        final CycleOption cycleOption = CycleOption.withoutId(
+                member,
+                input.title(),
+                OptionType.CUSTOM,
+                input.durations()
+        );
 
         final CycleOption savedCycleOption = cycleOptionRepository.save(cycleOption);
         return CycleOptionSaveOutput.from(savedCycleOption);
+    }
+
+    @Transactional
+    public CycleOptionSaveOutput updateCycleOption(
+            final DeviceIdentifier identifier,
+            final Long cycleOptionId,
+            final CycleOptionUpdateInput input
+    ) {
+        final Member member = memberRepository.findByIdentifier(identifier)
+                .orElseThrow(() -> new UnauthorizedException("유효하지 않은 디바이스입니다"));
+
+        final CycleOption cycleOption = cycleOptionRepository.findById(cycleOptionId)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 주기 옵션입니다."));
+
+        validateOwnership(cycleOption, member);
+        validateOptionType(cycleOption);
+
+        cycleOption.update(input.title(), input.durations());
+
+        return CycleOptionSaveOutput.from(cycleOption);
+    }
+
+    @Transactional
+    public void deleteCycleOption(final DeviceIdentifier identifier, final Long cycleOptionId) {
+        final Member member = memberRepository.findByIdentifier(identifier)
+                .orElseThrow(() -> new UnauthorizedException("유효하지 않은 디바이스입니다"));
+
+        final CycleOption cycleOption = cycleOptionRepository.findById(cycleOptionId)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 주기 옵션입니다."));
+
+        validateOwnership(cycleOption, member);
+        validateOptionType(cycleOption);
+
+        cycleOptionRepository.delete(cycleOption);
     }
 
     private void validateCycleOptionCount(final Member member) {
@@ -63,24 +97,15 @@ public class CycleOptionService {
         }
     }
 
-    private void validateDurations(final List<Duration> durations) {
-        if (durations.isEmpty()) {
-            throw new BadRequestException("주기는 최소 1개 이상이어야 합니다.");
+    private void validateOwnership(final CycleOption cycleOption, final Member member) {
+        if (!cycleOption.isOwner(member)) {
+            throw new ForbiddenException("해당 주기 옵션에 대한 권한이 없습니다.");
         }
+    }
 
-        boolean allTenMinutes = durations.stream()
-                .allMatch(d -> d.toMinutes() % 10 == 0 && d.toMinutes() > 0);
-        if (!allTenMinutes) {
-            throw new BadRequestException("주기는 10분 단위여야 합니다.");
-        }
-
-        if (durations.get(0).toMinutes() < 10) {
-            throw new BadRequestException("첫 번째 주기는 최소 10분 이상이어야 합니다.");
-        }
-
-        Duration lastDuration = durations.get(durations.size() - 1);
-        if (lastDuration.toDays() > 365) {
-            throw new BadRequestException("주기는 최대 1년 이내여야 합니다.");
+    private void validateOptionType(final CycleOption cycleOption) {
+        if (cycleOption.getOptionType() != OptionType.CUSTOM) {
+            throw new ForbiddenException("기본 주기는 수정/삭제할 수 없습니다.");
         }
     }
 }

--- a/src/main/java/com/recyclestudy/cycle/service/CycleOptionService.java
+++ b/src/main/java/com/recyclestudy/cycle/service/CycleOptionService.java
@@ -1,12 +1,18 @@
 package com.recyclestudy.cycle.service;
 
 import com.recyclestudy.cycle.domain.CycleOption;
+import com.recyclestudy.cycle.domain.CycleOptionDuration;
+import com.recyclestudy.cycle.domain.OptionType;
 import com.recyclestudy.cycle.repository.CycleOptionRepository;
+import com.recyclestudy.cycle.service.input.CycleOptionSaveInput;
 import com.recyclestudy.cycle.service.output.CycleOptionFindOutput;
+import com.recyclestudy.cycle.service.output.CycleOptionSaveOutput;
+import com.recyclestudy.exception.BadRequestException;
 import com.recyclestudy.exception.UnauthorizedException;
 import com.recyclestudy.member.domain.DeviceIdentifier;
 import com.recyclestudy.member.domain.Member;
 import com.recyclestudy.member.repository.MemberRepository;
+import java.time.Duration;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,5 +31,56 @@ public class CycleOptionService {
                 .orElseThrow(() -> new UnauthorizedException("유효하지 않은 디바이스입니다"));
         final List<CycleOption> cycleOptions = cycleOptionRepository.findAllByMember(member);
         return CycleOptionFindOutput.from(cycleOptions);
+    }
+
+    @Transactional
+    public CycleOptionSaveOutput saveCycleOption(final DeviceIdentifier identifier, final CycleOptionSaveInput input) {
+        final Member member = memberRepository.findByIdentifier(identifier)
+                .orElseThrow(() -> new UnauthorizedException("유효하지 않은 디바이스입니다"));
+
+        validateCycleOptionCount(member);
+        validateDurations(input.durations());
+
+        final CycleOption cycleOption = CycleOption.withoutId(member, input.title(), OptionType.CUSTOM);
+        final List<CycleOptionDuration> durations = input.durations().stream()
+                .map(duration -> CycleOptionDuration.of(cycleOption, duration))
+                .toList();
+
+        cycleOption.addDurations(durations);
+
+        final CycleOption savedCycleOption = cycleOptionRepository.save(cycleOption);
+        return CycleOptionSaveOutput.from(savedCycleOption);
+    }
+
+    private void validateCycleOptionCount(final Member member) {
+        final List<CycleOption> cycleOptions = cycleOptionRepository.findAllByMember(member);
+        long customCount = cycleOptions.stream()
+                .filter(option -> option.getOptionType() == OptionType.CUSTOM)
+                .count();
+
+        if (customCount >= 5) {
+            throw new BadRequestException("커스텀 주기는 최대 5개까지만 생성 가능합니다.");
+        }
+    }
+
+    private void validateDurations(final List<Duration> durations) {
+        if (durations.isEmpty()) {
+            throw new BadRequestException("주기는 최소 1개 이상이어야 합니다.");
+        }
+
+        boolean allTenMinutes = durations.stream()
+                .allMatch(d -> d.toMinutes() % 10 == 0 && d.toMinutes() > 0);
+        if (!allTenMinutes) {
+            throw new BadRequestException("주기는 10분 단위여야 합니다.");
+        }
+
+        if (durations.get(0).toMinutes() < 10) {
+            throw new BadRequestException("첫 번째 주기는 최소 10분 이상이어야 합니다.");
+        }
+
+        Duration lastDuration = durations.get(durations.size() - 1);
+        if (lastDuration.toDays() > 365) {
+            throw new BadRequestException("주기는 최대 1년 이내여야 합니다.");
+        }
     }
 }

--- a/src/main/java/com/recyclestudy/cycle/service/CycleOptionService.java
+++ b/src/main/java/com/recyclestudy/cycle/service/CycleOptionService.java
@@ -1,0 +1,29 @@
+package com.recyclestudy.cycle.service;
+
+import com.recyclestudy.cycle.domain.CycleOption;
+import com.recyclestudy.cycle.repository.CycleOptionRepository;
+import com.recyclestudy.cycle.service.output.CycleOptionFindOutput;
+import com.recyclestudy.exception.UnauthorizedException;
+import com.recyclestudy.member.domain.DeviceIdentifier;
+import com.recyclestudy.member.domain.Member;
+import com.recyclestudy.member.repository.MemberRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CycleOptionService {
+
+    private final MemberRepository memberRepository;
+    private final CycleOptionRepository cycleOptionRepository;
+
+    @Transactional(readOnly = true)
+    public CycleOptionFindOutput findAllCycleOptions(final DeviceIdentifier identifier) {
+        final Member member = memberRepository.findByIdentifier(identifier)
+                .orElseThrow(() -> new UnauthorizedException("유효하지 않은 디바이스입니다"));
+        final List<CycleOption> cycleOptions = cycleOptionRepository.findAllByMember(member);
+        return CycleOptionFindOutput.from(cycleOptions);
+    }
+}

--- a/src/main/java/com/recyclestudy/cycle/service/CycleOptionService.java
+++ b/src/main/java/com/recyclestudy/cycle/service/CycleOptionService.java
@@ -1,14 +1,13 @@
 package com.recyclestudy.cycle.service;
 
 import com.recyclestudy.cycle.domain.CycleOption;
-import com.recyclestudy.cycle.domain.OptionType;
+import com.recyclestudy.cycle.domain.DefaultCycleOption;
 import com.recyclestudy.cycle.repository.CycleOptionRepository;
 import com.recyclestudy.cycle.service.input.CycleOptionSaveInput;
 import com.recyclestudy.cycle.service.input.CycleOptionUpdateInput;
 import com.recyclestudy.cycle.service.output.CycleOptionFindOutput;
 import com.recyclestudy.cycle.service.output.CycleOptionSaveOutput;
 import com.recyclestudy.exception.BadRequestException;
-import com.recyclestudy.exception.ForbiddenException;
 import com.recyclestudy.exception.NotFoundException;
 import com.recyclestudy.exception.UnauthorizedException;
 import com.recyclestudy.member.domain.DeviceIdentifier;
@@ -30,8 +29,11 @@ public class CycleOptionService {
     public CycleOptionFindOutput findAllCycleOptions(final DeviceIdentifier identifier) {
         final Member member = memberRepository.findByIdentifier(identifier)
                 .orElseThrow(() -> new UnauthorizedException("유효하지 않은 디바이스입니다"));
-        final List<CycleOption> cycleOptions = cycleOptionRepository.findAllByMember(member);
-        return CycleOptionFindOutput.from(cycleOptions);
+
+        final List<DefaultCycleOption> defaultOptions = DefaultCycleOption.getAll();
+        final List<CycleOption> customOptions = cycleOptionRepository.findAllByMember(member);
+
+        return CycleOptionFindOutput.of(defaultOptions, customOptions);
     }
 
     @Transactional
@@ -44,7 +46,6 @@ public class CycleOptionService {
         final CycleOption cycleOption = CycleOption.withoutId(
                 member,
                 input.title(),
-                OptionType.CUSTOM,
                 input.durations()
         );
 
@@ -61,11 +62,10 @@ public class CycleOptionService {
         final Member member = memberRepository.findByIdentifier(identifier)
                 .orElseThrow(() -> new UnauthorizedException("유효하지 않은 디바이스입니다"));
 
-        final CycleOption cycleOption = cycleOptionRepository.findById(cycleOptionId)
+        final CycleOption cycleOption = cycleOptionRepository.findByIdWithDurations(cycleOptionId)
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 주기 옵션입니다."));
 
         validateOwnership(cycleOption, member);
-        validateOptionType(cycleOption);
 
         cycleOption.update(input.title(), input.durations());
 
@@ -81,31 +81,20 @@ public class CycleOptionService {
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 주기 옵션입니다."));
 
         validateOwnership(cycleOption, member);
-        validateOptionType(cycleOption);
 
         cycleOptionRepository.delete(cycleOption);
     }
 
     private void validateCycleOptionCount(final Member member) {
-        final List<CycleOption> cycleOptions = cycleOptionRepository.findAllByMember(member);
-        long customCount = cycleOptions.stream()
-                .filter(option -> option.getOptionType() == OptionType.CUSTOM)
-                .count();
-
-        if (customCount >= 5) {
+        final long count = cycleOptionRepository.countByMember(member);
+        if (count >= 5) {
             throw new BadRequestException("커스텀 주기는 최대 5개까지만 생성 가능합니다.");
         }
     }
 
     private void validateOwnership(final CycleOption cycleOption, final Member member) {
         if (!cycleOption.isOwner(member)) {
-            throw new ForbiddenException("해당 주기 옵션에 대한 권한이 없습니다.");
-        }
-    }
-
-    private void validateOptionType(final CycleOption cycleOption) {
-        if (cycleOption.getOptionType() != OptionType.CUSTOM) {
-            throw new ForbiddenException("기본 주기는 수정/삭제할 수 없습니다.");
+            throw new NotFoundException("존재하지 않는 주기 옵션입니다.");
         }
     }
 }

--- a/src/main/java/com/recyclestudy/cycle/service/input/CycleOptionSaveInput.java
+++ b/src/main/java/com/recyclestudy/cycle/service/input/CycleOptionSaveInput.java
@@ -1,0 +1,16 @@
+package com.recyclestudy.cycle.service.input;
+
+import com.recyclestudy.cycle.domain.CycleOptionTitle;
+import java.time.Duration;
+import java.util.List;
+
+public record CycleOptionSaveInput(CycleOptionTitle title, List<Duration> durations) {
+
+    public static CycleOptionSaveInput of(final String title, final List<String> durations) {
+        final CycleOptionTitle cycleOptionTitle = CycleOptionTitle.from(title);
+        final List<Duration> cycleOptionDurations = durations.stream()
+                .map(Duration::parse)
+                .toList();
+        return new CycleOptionSaveInput(cycleOptionTitle, cycleOptionDurations);
+    }
+}

--- a/src/main/java/com/recyclestudy/cycle/service/input/CycleOptionSaveInput.java
+++ b/src/main/java/com/recyclestudy/cycle/service/input/CycleOptionSaveInput.java
@@ -1,22 +1,8 @@
 package com.recyclestudy.cycle.service.input;
 
 import com.recyclestudy.cycle.domain.CycleOptionTitle;
-import com.recyclestudy.exception.BadRequestException;
 import java.time.Duration;
-import java.time.format.DateTimeParseException;
 import java.util.List;
 
 public record CycleOptionSaveInput(CycleOptionTitle title, List<Duration> durations) {
-
-    public static CycleOptionSaveInput of(final String title, final List<String> durations) {
-        final CycleOptionTitle cycleOptionTitle = CycleOptionTitle.from(title);
-        try {
-            final List<Duration> cycleOptionDurations = durations.stream()
-                    .map(Duration::parse)
-                    .toList();
-            return new CycleOptionSaveInput(cycleOptionTitle, cycleOptionDurations);
-        } catch (final DateTimeParseException e) {
-            throw new BadRequestException("잘못된 주기 형식입니다: ");
-        }
-    }
 }

--- a/src/main/java/com/recyclestudy/cycle/service/input/CycleOptionSaveInput.java
+++ b/src/main/java/com/recyclestudy/cycle/service/input/CycleOptionSaveInput.java
@@ -1,16 +1,22 @@
 package com.recyclestudy.cycle.service.input;
 
 import com.recyclestudy.cycle.domain.CycleOptionTitle;
+import com.recyclestudy.exception.BadRequestException;
 import java.time.Duration;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 
 public record CycleOptionSaveInput(CycleOptionTitle title, List<Duration> durations) {
 
     public static CycleOptionSaveInput of(final String title, final List<String> durations) {
         final CycleOptionTitle cycleOptionTitle = CycleOptionTitle.from(title);
-        final List<Duration> cycleOptionDurations = durations.stream()
-                .map(Duration::parse)
-                .toList();
-        return new CycleOptionSaveInput(cycleOptionTitle, cycleOptionDurations);
+        try {
+            final List<Duration> cycleOptionDurations = durations.stream()
+                    .map(Duration::parse)
+                    .toList();
+            return new CycleOptionSaveInput(cycleOptionTitle, cycleOptionDurations);
+        } catch (final DateTimeParseException e) {
+            throw new BadRequestException("잘못된 주기 형식입니다: ");
+        }
     }
 }

--- a/src/main/java/com/recyclestudy/cycle/service/input/CycleOptionUpdateInput.java
+++ b/src/main/java/com/recyclestudy/cycle/service/input/CycleOptionUpdateInput.java
@@ -5,12 +5,4 @@ import java.time.Duration;
 import java.util.List;
 
 public record CycleOptionUpdateInput(CycleOptionTitle title, List<Duration> durations) {
-
-    public static CycleOptionUpdateInput of(final String title, final List<String> durations) {
-        final CycleOptionTitle cycleOptionTitle = CycleOptionTitle.from(title);
-        final List<Duration> cycleOptionDurations = durations.stream()
-                .map(Duration::parse)
-                .toList();
-        return new CycleOptionUpdateInput(cycleOptionTitle, cycleOptionDurations);
-    }
 }

--- a/src/main/java/com/recyclestudy/cycle/service/input/CycleOptionUpdateInput.java
+++ b/src/main/java/com/recyclestudy/cycle/service/input/CycleOptionUpdateInput.java
@@ -1,0 +1,16 @@
+package com.recyclestudy.cycle.service.input;
+
+import com.recyclestudy.cycle.domain.CycleOptionTitle;
+import java.time.Duration;
+import java.util.List;
+
+public record CycleOptionUpdateInput(CycleOptionTitle title, List<Duration> durations) {
+
+    public static CycleOptionUpdateInput of(final String title, final List<String> durations) {
+        final CycleOptionTitle cycleOptionTitle = CycleOptionTitle.from(title);
+        final List<Duration> cycleOptionDurations = durations.stream()
+                .map(Duration::parse)
+                .toList();
+        return new CycleOptionUpdateInput(cycleOptionTitle, cycleOptionDurations);
+    }
+}

--- a/src/main/java/com/recyclestudy/cycle/service/output/CycleOptionFindOutput.java
+++ b/src/main/java/com/recyclestudy/cycle/service/output/CycleOptionFindOutput.java
@@ -1,0 +1,28 @@
+package com.recyclestudy.cycle.service.output;
+
+import com.recyclestudy.cycle.domain.CycleOption;
+import com.recyclestudy.cycle.domain.CycleOptionDuration;
+import com.recyclestudy.cycle.domain.CycleOptionDurationId;
+import com.recyclestudy.cycle.domain.CycleOptionTitle;
+import java.time.Duration;
+import java.util.List;
+
+public record CycleOptionFindOutput(List<CycleOptionElement> options) {
+
+    public static CycleOptionFindOutput from(final List<CycleOption> cycleOptions) {
+        final List<CycleOptionElement> optionElements = cycleOptions.stream()
+                .map(option -> new CycleOptionElement(
+                        option.getId(),
+                        option.getTitle(),
+                        option.getDurations().stream()
+                                .map(CycleOptionDuration::getId)
+                                .map(CycleOptionDurationId::getDuration)
+                                .toList()
+                ))
+                .toList();
+        return new CycleOptionFindOutput(optionElements);
+    }
+
+    public record CycleOptionElement(Long id, CycleOptionTitle title, List<Duration> durations) {
+    }
+}

--- a/src/main/java/com/recyclestudy/cycle/service/output/CycleOptionFindOutput.java
+++ b/src/main/java/com/recyclestudy/cycle/service/output/CycleOptionFindOutput.java
@@ -3,26 +3,44 @@ package com.recyclestudy.cycle.service.output;
 import com.recyclestudy.cycle.domain.CycleOption;
 import com.recyclestudy.cycle.domain.CycleOptionDuration;
 import com.recyclestudy.cycle.domain.CycleOptionDurationId;
-import com.recyclestudy.cycle.domain.CycleOptionTitle;
+import com.recyclestudy.cycle.domain.DefaultCycleOption;
 import java.time.Duration;
 import java.util.List;
 
-public record CycleOptionFindOutput(List<CycleOptionElement> options) {
+public record CycleOptionFindOutput(
+        List<DefaultOptionElement> defaultOptions,
+        List<CustomOptionElement> customOptions
+) {
 
-    public static CycleOptionFindOutput from(final List<CycleOption> cycleOptions) {
-        final List<CycleOptionElement> optionElements = cycleOptions.stream()
-                .map(option -> new CycleOptionElement(
-                        option.getId(),
+    public static CycleOptionFindOutput of(
+            final List<DefaultCycleOption> defaultCycleOptions,
+            final List<CycleOption> customCycleOptions
+    ) {
+        final List<DefaultOptionElement> defaultElements = defaultCycleOptions.stream()
+                .map(option -> new DefaultOptionElement(
+                        option.name(),
                         option.getTitle(),
+                        option.getDurations()
+                ))
+                .toList();
+
+        final List<CustomOptionElement> customElements = customCycleOptions.stream()
+                .map(option -> new CustomOptionElement(
+                        option.getId(),
+                        option.getTitle().getValue(),
                         option.getDurations().stream()
                                 .map(CycleOptionDuration::getId)
                                 .map(CycleOptionDurationId::getDuration)
                                 .toList()
                 ))
                 .toList();
-        return new CycleOptionFindOutput(optionElements);
+
+        return new CycleOptionFindOutput(defaultElements, customElements);
     }
 
-    public record CycleOptionElement(Long id, CycleOptionTitle title, List<Duration> durations) {
+    public record DefaultOptionElement(String code, String title, List<Duration> durations) {
+    }
+
+    public record CustomOptionElement(Long id, String title, List<Duration> durations) {
     }
 }

--- a/src/main/java/com/recyclestudy/cycle/service/output/CycleOptionSaveOutput.java
+++ b/src/main/java/com/recyclestudy/cycle/service/output/CycleOptionSaveOutput.java
@@ -1,0 +1,21 @@
+package com.recyclestudy.cycle.service.output;
+
+import com.recyclestudy.cycle.domain.CycleOption;
+import com.recyclestudy.cycle.domain.CycleOptionDuration;
+import com.recyclestudy.cycle.domain.CycleOptionTitle;
+import java.time.Duration;
+import java.util.List;
+
+public record CycleOptionSaveOutput(Long id, CycleOptionTitle title, List<Duration> durations) {
+
+    public static CycleOptionSaveOutput from(final CycleOption cycleOption) {
+        return new CycleOptionSaveOutput(
+                cycleOption.getId(),
+                cycleOption.getTitle(),
+                cycleOption.getDurations().stream()
+                        .map(CycleOptionDuration::getId)
+                        .map(id -> id.getDuration()) // Access duration from CycleOptionDurationId
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/recyclestudy/cycle/service/output/CycleOptionSaveOutput.java
+++ b/src/main/java/com/recyclestudy/cycle/service/output/CycleOptionSaveOutput.java
@@ -2,6 +2,7 @@ package com.recyclestudy.cycle.service.output;
 
 import com.recyclestudy.cycle.domain.CycleOption;
 import com.recyclestudy.cycle.domain.CycleOptionDuration;
+import com.recyclestudy.cycle.domain.CycleOptionDurationId;
 import com.recyclestudy.cycle.domain.CycleOptionTitle;
 import java.time.Duration;
 import java.util.List;
@@ -14,7 +15,7 @@ public record CycleOptionSaveOutput(Long id, CycleOptionTitle title, List<Durati
                 cycleOption.getTitle(),
                 cycleOption.getDurations().stream()
                         .map(CycleOptionDuration::getId)
-                        .map(id -> id.getDuration()) // Access duration from CycleOptionDurationId
+                        .map(CycleOptionDurationId::getDuration)
                         .toList()
         );
     }

--- a/src/main/java/com/recyclestudy/cycle/service/resolver/CustomCycleSelectionResolver.java
+++ b/src/main/java/com/recyclestudy/cycle/service/resolver/CustomCycleSelectionResolver.java
@@ -1,0 +1,33 @@
+package com.recyclestudy.cycle.service.resolver;
+
+import com.recyclestudy.cycle.domain.CycleOption;
+import com.recyclestudy.cycle.domain.CycleOptionDuration;
+import com.recyclestudy.cycle.domain.selection.CustomCycleSelection;
+import com.recyclestudy.cycle.repository.CycleOptionRepository;
+import com.recyclestudy.exception.NotFoundException;
+import java.time.Duration;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CustomCycleSelectionResolver implements CycleSelectionResolver<CustomCycleSelection> {
+
+    private final CycleOptionRepository cycleOptionRepository;
+
+    @Override
+    public Class<CustomCycleSelection> getSupportedType() {
+        return CustomCycleSelection.class;
+    }
+
+    @Override
+    public List<Duration> resolve(final CustomCycleSelection selection) {
+        final CycleOption cycleOption = cycleOptionRepository.findById(selection.id())
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 주기 옵션입니다."));
+
+        return cycleOption.getDurations().stream()
+                .map(CycleOptionDuration::getDuration)
+                .toList();
+    }
+}

--- a/src/main/java/com/recyclestudy/cycle/service/resolver/CycleSelectionResolver.java
+++ b/src/main/java/com/recyclestudy/cycle/service/resolver/CycleSelectionResolver.java
@@ -1,0 +1,12 @@
+package com.recyclestudy.cycle.service.resolver;
+
+import com.recyclestudy.cycle.domain.selection.CycleSelection;
+import java.time.Duration;
+import java.util.List;
+
+public interface CycleSelectionResolver<T extends CycleSelection> {
+
+    Class<T> getSupportedType();
+
+    List<Duration> resolve(T selection);
+}

--- a/src/main/java/com/recyclestudy/cycle/service/resolver/CycleSelectionResolverRegistry.java
+++ b/src/main/java/com/recyclestudy/cycle/service/resolver/CycleSelectionResolverRegistry.java
@@ -1,0 +1,35 @@
+package com.recyclestudy.cycle.service.resolver;
+
+import com.recyclestudy.cycle.domain.selection.CycleSelection;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CycleSelectionResolverRegistry {
+
+    private final Map<Class<? extends CycleSelection>, CycleSelectionResolver<?>> resolvers;
+
+    public CycleSelectionResolverRegistry(final List<CycleSelectionResolver<?>> resolverList) {
+        this.resolvers = resolverList.stream()
+                .collect(Collectors.toMap(
+                        CycleSelectionResolver::getSupportedType,
+                        Function.identity()
+                ));
+    }
+
+    @SuppressWarnings("unchecked")
+    public List<Duration> resolve(final CycleSelection selection) {
+        final CycleSelectionResolver<CycleSelection> resolver =
+                (CycleSelectionResolver<CycleSelection>) resolvers.get(selection.getClass());
+
+        if (resolver == null) {
+            throw new IllegalStateException("지원하지 않는 주기 타입입니다: " + selection.getClass().getSimpleName());
+        }
+
+        return resolver.resolve(selection);
+    }
+}

--- a/src/main/java/com/recyclestudy/cycle/service/resolver/DefaultCycleSelectionResolver.java
+++ b/src/main/java/com/recyclestudy/cycle/service/resolver/DefaultCycleSelectionResolver.java
@@ -1,0 +1,21 @@
+package com.recyclestudy.cycle.service.resolver;
+
+import com.recyclestudy.cycle.domain.DefaultCycleOption;
+import com.recyclestudy.cycle.domain.selection.DefaultCycleSelection;
+import java.time.Duration;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DefaultCycleSelectionResolver implements CycleSelectionResolver<DefaultCycleSelection> {
+
+    @Override
+    public Class<DefaultCycleSelection> getSupportedType() {
+        return DefaultCycleSelection.class;
+    }
+
+    @Override
+    public List<Duration> resolve(final DefaultCycleSelection selection) {
+        return DefaultCycleOption.valueOf(selection.code()).getDurations();
+    }
+}

--- a/src/main/java/com/recyclestudy/cycle/util/CycleDurationParser.java
+++ b/src/main/java/com/recyclestudy/cycle/util/CycleDurationParser.java
@@ -1,0 +1,26 @@
+package com.recyclestudy.cycle.util;
+
+import com.recyclestudy.exception.BadRequestException;
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+
+public final class CycleDurationParser {
+
+    private CycleDurationParser() {
+    }
+
+    public static List<Duration> parseList(final List<String> formats) {
+        return formats.stream()
+                .map(CycleDurationParser::parse)
+                .toList();
+    }
+
+    private static Duration parse(final String format) {
+        try {
+            return Duration.parse(format);
+        } catch (final DateTimeParseException e) {
+            throw new BadRequestException("잘못된 주기 형식입니다: %s".formatted(format));
+        }
+    }
+}

--- a/src/main/java/com/recyclestudy/exception/ForbiddenException.java
+++ b/src/main/java/com/recyclestudy/exception/ForbiddenException.java
@@ -1,0 +1,7 @@
+package com.recyclestudy.exception;
+
+public class ForbiddenException extends RuntimeException {
+    public ForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/recyclestudy/exception/GlobalControllerAdvice.java
+++ b/src/main/java/com/recyclestudy/exception/GlobalControllerAdvice.java
@@ -40,6 +40,13 @@ public class GlobalControllerAdvice {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);
     }
 
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<ErrorResponse> handleForbidden(final ForbiddenException e) {
+        log.warn("[FORBIDDEN] {}", e.getMessage());
+        final ErrorResponse response = ErrorResponse.from(e.getMessage());
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(response);
+    }
+
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ErrorResponse> handleIllegalArgument(final IllegalArgumentException e) {
         log.warn("[ILLEGAL_ARGUMENT] {}", e.getMessage());

--- a/src/main/java/com/recyclestudy/review/controller/ReviewController.java
+++ b/src/main/java/com/recyclestudy/review/controller/ReviewController.java
@@ -27,7 +27,7 @@ public class ReviewController {
             @AuthDevice final DeviceIdentifier identifier,
             @RequestBody ReviewSaveRequest request
     ) {
-        final ReviewSaveInput input = ReviewSaveInput.of(identifier, request.targetUrl());
+        final ReviewSaveInput input = ReviewSaveInput.of(identifier, request.targetUrl(), request.cycle());
         final ReviewSaveOutput output = reviewService.saveReview(input);
         ReviewSaveResponse response = ReviewSaveResponse.of(output.url(), output.scheduledAts());
         return ResponseEntity.status(HttpStatus.CREATED).body(response);

--- a/src/main/java/com/recyclestudy/review/controller/ReviewController.java
+++ b/src/main/java/com/recyclestudy/review/controller/ReviewController.java
@@ -12,7 +12,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -32,12 +31,5 @@ public class ReviewController {
         final ReviewSaveOutput output = reviewService.saveReview(input);
         ReviewSaveResponse response = ReviewSaveResponse.of(output.url(), output.scheduledAts());
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
-    }
-
-    private String getResolvedIdentifier(final String identifier, final String headerIdentifier) {
-        if (headerIdentifier == null) {
-            return identifier;
-        }
-        return headerIdentifier;
     }
 }

--- a/src/main/java/com/recyclestudy/review/controller/request/ReviewSaveRequest.java
+++ b/src/main/java/com/recyclestudy/review/controller/request/ReviewSaveRequest.java
@@ -1,4 +1,6 @@
 package com.recyclestudy.review.controller.request;
 
-public record ReviewSaveRequest(String targetUrl) {
+import com.recyclestudy.cycle.domain.selection.CycleSelection;
+
+public record ReviewSaveRequest(String targetUrl, CycleSelection cycle) {
 }

--- a/src/main/java/com/recyclestudy/review/domain/Review.java
+++ b/src/main/java/com/recyclestudy/review/domain/Review.java
@@ -28,7 +28,7 @@ public class Review extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
-    
+
     @Embedded
     @AttributeOverride(name = "value", column = @Column(name = "url", nullable = false, columnDefinition = "TEXT"))
     private ReviewURL url;

--- a/src/main/java/com/recyclestudy/review/service/ReviewService.java
+++ b/src/main/java/com/recyclestudy/review/service/ReviewService.java
@@ -19,6 +19,7 @@ import com.recyclestudy.review.service.output.ReviewSaveOutput;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -67,7 +68,7 @@ public class ReviewService {
     private List<LocalDateTime> calculateScheduledAts(final CycleSelection cycleSelection) {
         final CycleSelection resolvedCycle = resolveDefaultCycleIfNull(cycleSelection);
         final List<Duration> durations = cycleSelectionResolverRegistry.resolve(resolvedCycle);
-        final LocalDateTime baseTime = LocalDateTime.now(clock);
+        final LocalDateTime baseTime = LocalDateTime.now(clock).truncatedTo(ChronoUnit.MINUTES);
 
         return durations.stream()
                 .map(baseTime::plus)

--- a/src/main/java/com/recyclestudy/review/service/ReviewService.java
+++ b/src/main/java/com/recyclestudy/review/service/ReviewService.java
@@ -2,6 +2,7 @@ package com.recyclestudy.review.service;
 
 import com.recyclestudy.common.BaseEntity;
 import com.recyclestudy.cycle.domain.selection.CycleSelection;
+import com.recyclestudy.cycle.domain.selection.DefaultCycleSelection;
 import com.recyclestudy.cycle.service.resolver.CycleSelectionResolverRegistry;
 import com.recyclestudy.exception.UnauthorizedException;
 import com.recyclestudy.member.domain.Member;
@@ -64,12 +65,21 @@ public class ReviewService {
     }
 
     private List<LocalDateTime> calculateScheduledAts(final CycleSelection cycleSelection) {
-        final List<Duration> durations = cycleSelectionResolverRegistry.resolve(cycleSelection);
+        final CycleSelection resolvedCycle = resolveDefaultCycleIfNull(cycleSelection);
+        final List<Duration> durations = cycleSelectionResolverRegistry.resolve(resolvedCycle);
         final LocalDateTime baseTime = LocalDateTime.now(clock);
 
         return durations.stream()
                 .map(baseTime::plus)
                 .toList();
+    }
+
+    @Deprecated // 프론트 마이그레이션 완료 후 제거 예정
+    private CycleSelection resolveDefaultCycleIfNull(final CycleSelection cycleSelection) {
+        if (cycleSelection != null) {
+            return cycleSelection;
+        }
+        return new DefaultCycleSelection("EBBINGHAUS");
     }
 
     private void savePendingNotificationHistory(final List<ReviewCycle> savedReviewCycles) {

--- a/src/main/java/com/recyclestudy/review/service/ReviewService.java
+++ b/src/main/java/com/recyclestudy/review/service/ReviewService.java
@@ -3,7 +3,6 @@ package com.recyclestudy.review.service;
 import com.recyclestudy.common.BaseEntity;
 import com.recyclestudy.exception.UnauthorizedException;
 import com.recyclestudy.member.domain.Member;
-import com.recyclestudy.member.repository.DeviceRepository;
 import com.recyclestudy.member.repository.MemberRepository;
 import com.recyclestudy.review.domain.NotificationHistory;
 import com.recyclestudy.review.domain.NotificationStatus;
@@ -31,7 +30,6 @@ public class ReviewService {
 
     private final ReviewRepository reviewRepository;
     private final ReviewCycleRepository reviewCycleRepository;
-    private final DeviceRepository deviceRepository;
     private final MemberRepository memberRepository;
     private final NotificationHistoryRepository notificationHistoryRepository;
     private final Clock clock;

--- a/src/main/java/com/recyclestudy/review/service/ReviewService.java
+++ b/src/main/java/com/recyclestudy/review/service/ReviewService.java
@@ -1,6 +1,8 @@
 package com.recyclestudy.review.service;
 
 import com.recyclestudy.common.BaseEntity;
+import com.recyclestudy.cycle.domain.selection.CycleSelection;
+import com.recyclestudy.cycle.service.resolver.CycleSelectionResolverRegistry;
 import com.recyclestudy.exception.UnauthorizedException;
 import com.recyclestudy.member.domain.Member;
 import com.recyclestudy.member.repository.MemberRepository;
@@ -8,14 +10,13 @@ import com.recyclestudy.review.domain.NotificationHistory;
 import com.recyclestudy.review.domain.NotificationStatus;
 import com.recyclestudy.review.domain.Review;
 import com.recyclestudy.review.domain.ReviewCycle;
-import com.recyclestudy.review.domain.ReviewCycleDuration;
 import com.recyclestudy.review.repository.NotificationHistoryRepository;
 import com.recyclestudy.review.repository.ReviewCycleRepository;
 import com.recyclestudy.review.repository.ReviewRepository;
 import com.recyclestudy.review.service.input.ReviewSaveInput;
 import com.recyclestudy.review.service.output.ReviewSaveOutput;
 import java.time.Clock;
-import java.time.LocalDate;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +32,7 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final ReviewCycleRepository reviewCycleRepository;
     private final MemberRepository memberRepository;
+    private final CycleSelectionResolverRegistry cycleSelectionResolverRegistry;
     private final NotificationHistoryRepository notificationHistoryRepository;
     private final Clock clock;
 
@@ -43,8 +45,7 @@ public class ReviewService {
         final Review savedReview = reviewRepository.save(review);
         log.info("[REVIEW_SAVED] 복습 주제 저장 성공: reviewId={}", savedReview.getId());
 
-        final LocalDate current = LocalDate.now(clock);
-        final List<LocalDateTime> scheduledAts = ReviewCycleDuration.calculate(current);
+        final List<LocalDateTime> scheduledAts = calculateScheduledAts(input.cycle());
 
         final List<ReviewCycle> reviewCycles = scheduledAts.stream()
                 .map(scheduledAt -> ReviewCycle.withoutId(savedReview, scheduledAt))
@@ -60,6 +61,15 @@ public class ReviewService {
         savePendingNotificationHistory(savedReviewCycles);
 
         return ReviewSaveOutput.of(savedReview.getUrl(), savedScheduledAts);
+    }
+
+    private List<LocalDateTime> calculateScheduledAts(final CycleSelection cycleSelection) {
+        final List<Duration> durations = cycleSelectionResolverRegistry.resolve(cycleSelection);
+        final LocalDateTime baseTime = LocalDateTime.now(clock);
+
+        return durations.stream()
+                .map(baseTime::plus)
+                .toList();
     }
 
     private void savePendingNotificationHistory(final List<ReviewCycle> savedReviewCycles) {

--- a/src/main/java/com/recyclestudy/review/service/input/ReviewSaveInput.java
+++ b/src/main/java/com/recyclestudy/review/service/input/ReviewSaveInput.java
@@ -1,12 +1,17 @@
 package com.recyclestudy.review.service.input;
 
+import com.recyclestudy.cycle.domain.selection.CycleSelection;
 import com.recyclestudy.member.domain.DeviceIdentifier;
 import com.recyclestudy.review.domain.ReviewURL;
 
-public record ReviewSaveInput(DeviceIdentifier identifier, ReviewURL url) {
+public record ReviewSaveInput(DeviceIdentifier identifier, ReviewURL url, CycleSelection cycle) {
 
-    public static ReviewSaveInput of(final DeviceIdentifier identifier, final String url) {
+    public static ReviewSaveInput of(
+            final DeviceIdentifier identifier,
+            final String url,
+            final CycleSelection cycle
+    ) {
         final ReviewURL reviewURL = ReviewURL.from(url);
-        return new ReviewSaveInput(identifier, reviewURL);
+        return new ReviewSaveInput(identifier, reviewURL, cycle);
     }
 }

--- a/src/main/resources/db/migration/V20260129_1__create_cycle_option_tables.sql
+++ b/src/main/resources/db/migration/V20260129_1__create_cycle_option_tables.sql
@@ -4,7 +4,6 @@ create table cycle_option
     id          bigint auto_increment primary key,
     member_id   bigint       not null,
     title       varchar(255) not null,
-    option_type varchar(255) not null,
     created_at  datetime(6)  not null,
     modified_at datetime(6)  null,
     constraint fk_cycle_option_member_id

--- a/src/main/resources/db/migration/V20260129_1__create_cycle_option_tables.sql
+++ b/src/main/resources/db/migration/V20260129_1__create_cycle_option_tables.sql
@@ -1,0 +1,23 @@
+-- cycle_option
+create table cycle_option
+(
+    id          bigint auto_increment primary key,
+    member_id   bigint       not null,
+    title       varchar(255) not null,
+    option_type varchar(255) not null,
+    created_at  datetime(6)  not null,
+    modified_at datetime(6)  null,
+    constraint fk_cycle_option_member_id
+        foreign key (member_id) references member (id)
+);
+
+-- cycle_option_duration
+create table cycle_option_duration
+(
+    cycle_option_id bigint      not null,
+    duration        bigint      not null,
+    constraint pk_cycle_option_duration
+        primary key (cycle_option_id, duration),
+    constraint fk_cycle_option_duration_cycle_option_id
+        foreign key (cycle_option_id) references cycle_option (id)
+);

--- a/src/test/java/com/recyclestudy/cycle/controller/CycleOptionControllerTest.java
+++ b/src/test/java/com/recyclestudy/cycle/controller/CycleOptionControllerTest.java
@@ -1,6 +1,7 @@
 package com.recyclestudy.cycle.controller;
 
 import com.recyclestudy.cycle.controller.request.CycleOptionSaveRequest;
+import com.recyclestudy.cycle.controller.request.CycleOptionUpdateRequest;
 import com.recyclestudy.cycle.domain.CycleOptionTitle;
 import com.recyclestudy.cycle.service.CycleOptionService;
 import com.recyclestudy.cycle.service.output.CycleOptionFindOutput;
@@ -35,6 +36,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 
 class CycleOptionControllerTest extends APIBaseTest {
 
@@ -155,7 +157,8 @@ class CycleOptionControllerTest extends APIBaseTest {
                                 )
                                 .requestFields(
                                         fieldWithPath("title").type(JsonFieldType.STRING).description("주기 옵션 제목"),
-                                        fieldWithPath("durations").type(JsonFieldType.ARRAY).description("주기 시간 목록 (ISO 8601 Duration)")
+                                        fieldWithPath("durations").type(JsonFieldType.ARRAY)
+                                                .description("주기 시간 목록 (ISO 8601 Duration)")
                                 )
                                 .responseFields(
                                         fieldWithPath("id").type(JsonFieldType.NUMBER).description("생성된 주기 옵션 ID"),
@@ -211,5 +214,88 @@ class CycleOptionControllerTest extends APIBaseTest {
                 .then()
                 .statusCode(HttpStatus.BAD_REQUEST.value())
                 .body("message", equalTo("주기는 10분 단위여야 합니다."));
+    }
+
+    @Test
+    @DisplayName("커스텀 주기 옵션을 수정한다")
+    void updateCycleOption() {
+        // given
+        final String headerIdentifier = "device-id";
+        final Long cycleOptionId = 1L;
+        final CycleOptionUpdateRequest request = new CycleOptionUpdateRequest(
+                "updated title",
+                List.of("PT20M")
+        );
+        final CycleOptionSaveOutput output = new CycleOptionSaveOutput(
+                cycleOptionId,
+                CycleOptionTitle.from("updated title"),
+                List.of(Duration.ofMinutes(20))
+        );
+
+        given(cycleOptionService.updateCycleOption(any(), any(), any())).willReturn(output);
+
+        // when
+        // then
+        given(this.spec)
+                .filter(document(DEFAULT_REST_DOC_PATH,
+                        builder()
+                                .tag("CycleOption")
+                                .summary("커스텀 주기 옵션 수정")
+                                .description("기존 커스텀 주기 옵션을 수정한다")
+                                .requestHeaders(
+                                        headerWithName("X-Device-Id").description("디바이스 식별자")
+                                )
+                                .pathParameters(
+                                        parameterWithName("id").description("수정할 주기 옵션 ID")
+                                )
+                                .requestFields(
+                                        fieldWithPath("title").type(JsonFieldType.STRING).description("수정할 주기 옵션 제목"),
+                                        fieldWithPath("durations").type(JsonFieldType.ARRAY)
+                                                .description("수정할 주기 시간 목록")
+                                )
+                                .responseFields(
+                                        fieldWithPath("id").type(JsonFieldType.NUMBER).description("주기 옵션 ID"),
+                                        fieldWithPath("title").type(JsonFieldType.STRING).description("주기 옵션 제목"),
+                                        fieldWithPath("durations").type(JsonFieldType.ARRAY).description("주기 시간 목록")
+                                )
+                ))
+                .header("X-Device-Id", headerIdentifier)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .when()
+                .put("/api/v1/cycles/custom/{id}", cycleOptionId)
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .body("title", equalTo("updated title"))
+                .body("durations", hasSize(1));
+    }
+
+    @Test
+    @DisplayName("커스텀 주기 옵션을 삭제한다")
+    void deleteCycleOption() {
+        // given
+        final String headerIdentifier = "device-id";
+        final Long cycleOptionId = 1L;
+
+        // when
+        // then
+        given(this.spec)
+                .filter(document(DEFAULT_REST_DOC_PATH,
+                        builder()
+                                .tag("CycleOption")
+                                .summary("커스텀 주기 옵션 삭제")
+                                .description("커스텀 주기 옵션을 삭제한다")
+                                .requestHeaders(
+                                        headerWithName("X-Device-Id").description("디바이스 식별자")
+                                )
+                                .pathParameters(
+                                        parameterWithName("id").description("삭제할 주기 옵션 ID")
+                                )
+                ))
+                .header("X-Device-Id", headerIdentifier)
+                .when()
+                .delete("/api/v1/cycles/custom/{id}", cycleOptionId)
+                .then()
+                .statusCode(HttpStatus.NO_CONTENT.value());
     }
 }

--- a/src/test/java/com/recyclestudy/cycle/controller/CycleOptionControllerTest.java
+++ b/src/test/java/com/recyclestudy/cycle/controller/CycleOptionControllerTest.java
@@ -1,0 +1,123 @@
+package com.recyclestudy.cycle.controller;
+
+import com.recyclestudy.cycle.domain.CycleOptionTitle;
+import com.recyclestudy.cycle.service.CycleOptionService;
+import com.recyclestudy.cycle.service.output.CycleOptionFindOutput;
+import com.recyclestudy.exception.UnauthorizedException;
+import com.recyclestudy.member.domain.ActivationExpiredDateTime;
+import com.recyclestudy.member.domain.Device;
+import com.recyclestudy.member.domain.DeviceIdentifier;
+import com.recyclestudy.member.domain.Email;
+import com.recyclestudy.member.domain.Member;
+import com.recyclestudy.member.repository.DeviceRepository;
+import com.recyclestudy.restdocs.APIBaseTest;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import static com.epages.restdocs.apispec.ResourceSnippetParameters.builder;
+import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+
+class CycleOptionControllerTest extends APIBaseTest {
+
+    @MockitoBean
+    private CycleOptionService cycleOptionService;
+
+    @MockitoBean
+    private DeviceRepository deviceRepository;
+
+    @BeforeEach
+    void setUpMocks(RestDocumentationContextProvider provider) {
+        super.setUpRestDocs(provider);
+        // Default mock: device exists and is active
+        final Member member = Member.withoutId(Email.from("test@test.com"));
+        final Device activeDevice = Device.withoutId(member, DeviceIdentifier.from("device-id"),
+                true, ActivationExpiredDateTime.create(LocalDateTime.now()));
+        given(deviceRepository.findByIdentifier(any(DeviceIdentifier.class))).willReturn(Optional.of(activeDevice));
+    }
+
+    @Test
+    @DisplayName("멤버의 주기 옵션을 조회한다")
+    void findAllCycleOptions() {
+        // given
+        final String headerIdentifier = "device-id";
+        final CycleOptionFindOutput.CycleOptionElement option = new CycleOptionFindOutput.CycleOptionElement(
+                1L,
+                CycleOptionTitle.from("title"),
+                List.of(Duration.ofMinutes(10), Duration.ofHours(1))
+        );
+        final CycleOptionFindOutput output = new CycleOptionFindOutput(List.of(option));
+
+        given(cycleOptionService.findAllCycleOptions(any())).willReturn(output);
+
+        // when
+        // then
+        given(this.spec)
+                .filter(document(DEFAULT_REST_DOC_PATH,
+                        builder()
+                                .tag("CycleOption")
+                                .summary("주기 옵션 조회")
+                                .description("멤버의 주기 옵션을 조회한다")
+                                .requestHeaders(
+                                        headerWithName("X-Device-Id").description("디바이스 식별자")
+                                )
+                                .responseFields(
+                                        fieldWithPath("options").type(JsonFieldType.ARRAY).description("주기 옵션 목록"),
+                                        fieldWithPath("options[].id").type(JsonFieldType.NUMBER)
+                                                .description("주기 옵션 ID"),
+                                        fieldWithPath("options[].title").type(JsonFieldType.STRING)
+                                                .description("주기 옵션 제목"),
+                                        fieldWithPath("options[].durations").type(JsonFieldType.ARRAY)
+                                                .description("주기 시간 목록 (ISO 8601 Duration)")
+                                )
+                ))
+                .header("X-Device-Id", headerIdentifier)
+                .when()
+                .get("/api/v1/cycles/custom")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .body("options", hasSize(1));
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 디바이스로 조회 시 401 응답을 반환한다")
+    void findAllCycleOptions_Unauthorized() {
+        // given
+        final String headerIdentifier = "device-id";
+
+        given(deviceRepository.findByIdentifier(any()))
+                .willReturn(Optional.empty());
+
+        // when
+        // then
+        given(this.spec)
+                .filter(document(DEFAULT_REST_DOC_PATH,
+                        builder()
+                                .tag("CycleOption")
+                                .summary("주기 옵션 조회")
+                                .description("유효하지 않은 디바이스로 조회 시 401 응답을 반환한다")
+                                .requestHeaders(
+                                        headerWithName("X-Device-Id").description("디바이스 식별자")
+                                )
+                ))
+                .header("X-Device-Id", headerIdentifier)
+                .when()
+                .get("/api/v1/cycles/custom")
+                .then()
+                .statusCode(HttpStatus.UNAUTHORIZED.value());
+    }
+}

--- a/src/test/java/com/recyclestudy/cycle/controller/CycleOptionControllerTest.java
+++ b/src/test/java/com/recyclestudy/cycle/controller/CycleOptionControllerTest.java
@@ -2,7 +2,9 @@ package com.recyclestudy.cycle.controller;
 
 import com.recyclestudy.cycle.controller.request.CycleOptionSaveRequest;
 import com.recyclestudy.cycle.controller.request.CycleOptionUpdateRequest;
+import com.recyclestudy.cycle.domain.CycleOption;
 import com.recyclestudy.cycle.domain.CycleOptionTitle;
+import com.recyclestudy.cycle.domain.DefaultCycleOption;
 import com.recyclestudy.cycle.service.CycleOptionService;
 import com.recyclestudy.cycle.service.output.CycleOptionFindOutput;
 import com.recyclestudy.cycle.service.output.CycleOptionSaveOutput;
@@ -26,6 +28,7 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static com.epages.restdocs.apispec.ResourceSnippetParameters.builder;
 import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
@@ -61,19 +64,17 @@ class CycleOptionControllerTest extends APIBaseTest {
     void findAllCycleOptions() {
         // given
         final String headerIdentifier = "device-id";
-        final CycleOptionFindOutput.DefaultOptionElement defaultOption = new CycleOptionFindOutput.DefaultOptionElement(
-                "EBBINGHAUS",
-                "에빙하우스 망각곡선",
+        final Member member = Member.withoutId(Email.from("test@test.com"));
+        final CycleOption customCycleOption = CycleOption.withoutId(
+                member,
+                CycleOptionTitle.from("custom title"),
                 List.of(Duration.ofMinutes(10), Duration.ofHours(1))
         );
-        final CycleOptionFindOutput.CustomOptionElement customOption = new CycleOptionFindOutput.CustomOptionElement(
-                1L,
-                "custom title",
-                List.of(Duration.ofMinutes(10), Duration.ofHours(1))
-        );
-        final CycleOptionFindOutput output = new CycleOptionFindOutput(
-                List.of(defaultOption),
-                List.of(customOption)
+        ReflectionTestUtils.setField(customCycleOption, "id", 1L);
+
+        final CycleOptionFindOutput output = CycleOptionFindOutput.of(
+                List.of(DefaultCycleOption.EBBINGHAUS),
+                List.of(customCycleOption)
         );
 
         given(cycleOptionService.findAllCycleOptions(any())).willReturn(output);
@@ -154,11 +155,16 @@ class CycleOptionControllerTest extends APIBaseTest {
                 "custom title",
                 List.of("PT10M", "P1D")
         );
-        final CycleOptionSaveOutput output = new CycleOptionSaveOutput(
-                1L,
+
+        final Member member = Member.withoutId(Email.from("test@test.com"));
+        final CycleOption customCycleOption = CycleOption.withoutId(
+                member,
                 CycleOptionTitle.from("custom title"),
                 List.of(Duration.ofMinutes(10), Duration.ofDays(1))
         );
+        ReflectionTestUtils.setField(customCycleOption, "id", 1L);
+
+        final CycleOptionSaveOutput output = CycleOptionSaveOutput.from(customCycleOption);
 
         given(cycleOptionService.saveCycleOption(any(), any())).willReturn(output);
 
@@ -244,11 +250,16 @@ class CycleOptionControllerTest extends APIBaseTest {
                 "updated title",
                 List.of("PT20M")
         );
-        final CycleOptionSaveOutput output = new CycleOptionSaveOutput(
-                cycleOptionId,
+
+        final Member member = Member.withoutId(Email.from("test@test.com"));
+        final CycleOption customCycleOption = CycleOption.withoutId(
+                member,
                 CycleOptionTitle.from("updated title"),
                 List.of(Duration.ofMinutes(20))
         );
+        ReflectionTestUtils.setField(customCycleOption, "id", cycleOptionId);
+
+        final CycleOptionSaveOutput output = CycleOptionSaveOutput.from(customCycleOption);
 
         given(cycleOptionService.updateCycleOption(any(), any(), any())).willReturn(output);
 

--- a/src/test/java/com/recyclestudy/cycle/controller/CycleOptionControllerTest.java
+++ b/src/test/java/com/recyclestudy/cycle/controller/CycleOptionControllerTest.java
@@ -1,9 +1,11 @@
 package com.recyclestudy.cycle.controller;
 
+import com.recyclestudy.cycle.controller.request.CycleOptionSaveRequest;
 import com.recyclestudy.cycle.domain.CycleOptionTitle;
 import com.recyclestudy.cycle.service.CycleOptionService;
 import com.recyclestudy.cycle.service.output.CycleOptionFindOutput;
-import com.recyclestudy.exception.UnauthorizedException;
+import com.recyclestudy.cycle.service.output.CycleOptionSaveOutput;
+import com.recyclestudy.exception.BadRequestException;
 import com.recyclestudy.member.domain.ActivationExpiredDateTime;
 import com.recyclestudy.member.domain.Device;
 import com.recyclestudy.member.domain.DeviceIdentifier;
@@ -19,6 +21,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -26,6 +29,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import static com.epages.restdocs.apispec.ResourceSnippetParameters.builder;
 import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -119,5 +123,93 @@ class CycleOptionControllerTest extends APIBaseTest {
                 .get("/api/v1/cycles/custom")
                 .then()
                 .statusCode(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    @Test
+    @DisplayName("커스텀 주기 옵션을 저장한다")
+    void saveCycleOption() {
+        // given
+        final String headerIdentifier = "device-id";
+        final CycleOptionSaveRequest request = new CycleOptionSaveRequest(
+                "custom title",
+                List.of("PT10M", "P1D")
+        );
+        final CycleOptionSaveOutput output = new CycleOptionSaveOutput(
+                1L,
+                CycleOptionTitle.from("custom title"),
+                List.of(Duration.ofMinutes(10), Duration.ofDays(1))
+        );
+
+        given(cycleOptionService.saveCycleOption(any(), any())).willReturn(output);
+
+        // when
+        // then
+        given(this.spec)
+                .filter(document(DEFAULT_REST_DOC_PATH,
+                        builder()
+                                .tag("CycleOption")
+                                .summary("커스텀 주기 옵션 저장")
+                                .description("새로운 커스텀 주기 옵션을 저장한다")
+                                .requestHeaders(
+                                        headerWithName("X-Device-Id").description("디바이스 식별자")
+                                )
+                                .requestFields(
+                                        fieldWithPath("title").type(JsonFieldType.STRING).description("주기 옵션 제목"),
+                                        fieldWithPath("durations").type(JsonFieldType.ARRAY).description("주기 시간 목록 (ISO 8601 Duration)")
+                                )
+                                .responseFields(
+                                        fieldWithPath("id").type(JsonFieldType.NUMBER).description("생성된 주기 옵션 ID"),
+                                        fieldWithPath("title").type(JsonFieldType.STRING).description("주기 옵션 제목"),
+                                        fieldWithPath("durations").type(JsonFieldType.ARRAY).description("주기 시간 목록")
+                                )
+                ))
+                .header("X-Device-Id", headerIdentifier)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .when()
+                .post("/api/v1/cycles/custom")
+                .then()
+                .statusCode(HttpStatus.CREATED.value())
+                .header("Location", "/api/v1/cycles/custom/1")
+                .body("title", equalTo("custom title"))
+                .body("durations", hasSize(2));
+    }
+
+    @Test
+    @DisplayName("잘못된 요청 데이터로 저장 시 400 응답을 반환한다")
+    void saveCycleOption_BadRequest() {
+        // given
+        final String headerIdentifier = "device-id";
+        final CycleOptionSaveRequest request = new CycleOptionSaveRequest(
+                "title",
+                List.of("PT5M")
+        );
+
+        given(cycleOptionService.saveCycleOption(any(), any()))
+                .willThrow(new BadRequestException("주기는 10분 단위여야 합니다."));
+
+        // when
+        // then
+        given(this.spec)
+                .filter(document(DEFAULT_REST_DOC_PATH,
+                        builder()
+                                .tag("CycleOption")
+                                .summary("커스텀 주기 옵션 저장")
+                                .description("잘못된 데이터로 저장 시 400 응답을 반환한다")
+                                .requestHeaders(
+                                        headerWithName("X-Device-Id").description("디바이스 식별자")
+                                )
+                                .responseFields(
+                                        fieldWithPath("message").type(JsonFieldType.STRING).description("에러 메시지")
+                                )
+                ))
+                .header("X-Device-Id", headerIdentifier)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .when()
+                .post("/api/v1/cycles/custom")
+                .then()
+                .statusCode(HttpStatus.BAD_REQUEST.value())
+                .body("message", equalTo("주기는 10분 단위여야 합니다."));
     }
 }

--- a/src/test/java/com/recyclestudy/cycle/controller/CycleOptionControllerTest.java
+++ b/src/test/java/com/recyclestudy/cycle/controller/CycleOptionControllerTest.java
@@ -61,12 +61,20 @@ class CycleOptionControllerTest extends APIBaseTest {
     void findAllCycleOptions() {
         // given
         final String headerIdentifier = "device-id";
-        final CycleOptionFindOutput.CycleOptionElement option = new CycleOptionFindOutput.CycleOptionElement(
-                1L,
-                CycleOptionTitle.from("title"),
+        final CycleOptionFindOutput.DefaultOptionElement defaultOption = new CycleOptionFindOutput.DefaultOptionElement(
+                "EBBINGHAUS",
+                "에빙하우스 망각곡선",
                 List.of(Duration.ofMinutes(10), Duration.ofHours(1))
         );
-        final CycleOptionFindOutput output = new CycleOptionFindOutput(List.of(option));
+        final CycleOptionFindOutput.CustomOptionElement customOption = new CycleOptionFindOutput.CustomOptionElement(
+                1L,
+                "custom title",
+                List.of(Duration.ofMinutes(10), Duration.ofHours(1))
+        );
+        final CycleOptionFindOutput output = new CycleOptionFindOutput(
+                List.of(defaultOption),
+                List.of(customOption)
+        );
 
         given(cycleOptionService.findAllCycleOptions(any())).willReturn(output);
 
@@ -82,12 +90,21 @@ class CycleOptionControllerTest extends APIBaseTest {
                                         headerWithName("X-Device-Id").description("디바이스 식별자")
                                 )
                                 .responseFields(
-                                        fieldWithPath("options").type(JsonFieldType.ARRAY).description("주기 옵션 목록"),
-                                        fieldWithPath("options[].id").type(JsonFieldType.NUMBER)
-                                                .description("주기 옵션 ID"),
-                                        fieldWithPath("options[].title").type(JsonFieldType.STRING)
-                                                .description("주기 옵션 제목"),
-                                        fieldWithPath("options[].durations").type(JsonFieldType.ARRAY)
+                                        fieldWithPath("defaultOptions").type(JsonFieldType.ARRAY)
+                                                .description("기본 주기 옵션 목록"),
+                                        fieldWithPath("defaultOptions[].code").type(JsonFieldType.STRING)
+                                                .description("기본 주기 옵션 코드"),
+                                        fieldWithPath("defaultOptions[].title").type(JsonFieldType.STRING)
+                                                .description("기본 주기 옵션 제목"),
+                                        fieldWithPath("defaultOptions[].durations").type(JsonFieldType.ARRAY)
+                                                .description("주기 시간 목록 (ISO 8601 Duration)"),
+                                        fieldWithPath("customOptions").type(JsonFieldType.ARRAY)
+                                                .description("커스텀 주기 옵션 목록"),
+                                        fieldWithPath("customOptions[].id").type(JsonFieldType.NUMBER)
+                                                .description("커스텀 주기 옵션 ID"),
+                                        fieldWithPath("customOptions[].title").type(JsonFieldType.STRING)
+                                                .description("커스텀 주기 옵션 제목"),
+                                        fieldWithPath("customOptions[].durations").type(JsonFieldType.ARRAY)
                                                 .description("주기 시간 목록 (ISO 8601 Duration)")
                                 )
                 ))
@@ -96,7 +113,8 @@ class CycleOptionControllerTest extends APIBaseTest {
                 .get("/api/v1/cycles/custom")
                 .then()
                 .statusCode(HttpStatus.OK.value())
-                .body("options", hasSize(1));
+                .body("defaultOptions", hasSize(1))
+                .body("customOptions", hasSize(1));
     }
 
     @Test

--- a/src/test/java/com/recyclestudy/cycle/domain/CycleDurationsTest.java
+++ b/src/test/java/com/recyclestudy/cycle/domain/CycleDurationsTest.java
@@ -20,22 +20,27 @@ class CycleDurationsTest {
 
     private CycleOption cycleOption;
 
+    private static Stream<Arguments> provideInvalidDurations() {
+        return Stream.of(
+                Arguments.of(List.of(), "주기는 최소 1개 이상이어야 합니다."),
+                Arguments.of(List.of("PT10M", "PT10M"), "중복된 주기가 존재합니다."),
+                Arguments.of(List.of("-PT10M"), "주기는 10분 단위여야 합니다."),
+                Arguments.of(List.of("PT0S"), "주기는 10분 단위여야 합니다."),
+                Arguments.of(List.of("PT5M"), "주기는 10분 단위여야 합니다."),
+                Arguments.of(List.of("PT15M"), "주기는 10분 단위여야 합니다."),
+                Arguments.of(List.of("PT1M"), "주기는 10분 단위여야 합니다."),
+                Arguments.of(List.of("P366D"), "주기는 최대 1년 이내여야 합니다."),
+                Arguments.of(List.of("PT10M", "P400D"), "주기는 최대 1년 이내여야 합니다.")
+        );
+    }
+
     @BeforeEach
     void setup() {
         final Member member = Member.withoutId(Email.from("test@test.com"));
         cycleOption = CycleOption.withoutId(
                 member,
                 CycleOptionTitle.from("title"),
-                OptionType.CUSTOM,
                 List.of(Duration.ofMinutes(10))
-        );
-    }
-
-    private static Stream<Arguments> provideInvalidDurations() {
-        return Stream.of(
-                Arguments.of(List.of(), "주기는 최소 1개 이상이어야 합니다."),
-                Arguments.of(List.of("PT5M"), "주기는 10분 단위여야 합니다."),
-                Arguments.of(List.of("P366D"), "주기는 최대 1년 이내여야 합니다.")
         );
     }
 
@@ -49,7 +54,7 @@ class CycleDurationsTest {
         );
 
         // when
-        final CycleDurations actual = new CycleDurations(durations);
+        final CycleDurations actual = CycleDurations.from(durations);
 
         // then
         assertThat(actual.getValues()).hasSize(2);
@@ -66,7 +71,7 @@ class CycleDurationsTest {
 
         // when
         // then
-        assertThatThrownBy(() -> new CycleDurations(durations))
+        assertThatThrownBy(() -> CycleDurations.from(durations))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(errorMessage);
     }

--- a/src/test/java/com/recyclestudy/cycle/domain/CycleDurationsTest.java
+++ b/src/test/java/com/recyclestudy/cycle/domain/CycleDurationsTest.java
@@ -1,0 +1,73 @@
+package com.recyclestudy.cycle.domain;
+
+import com.recyclestudy.exception.BadRequestException;
+import com.recyclestudy.member.domain.Email;
+import com.recyclestudy.member.domain.Member;
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CycleDurationsTest {
+
+    private CycleOption cycleOption;
+
+    @BeforeEach
+    void setup() {
+        final Member member = Member.withoutId(Email.from("test@test.com"));
+        cycleOption = CycleOption.withoutId(
+                member,
+                CycleOptionTitle.from("title"),
+                OptionType.CUSTOM,
+                List.of(Duration.ofMinutes(10))
+        );
+    }
+
+    private static Stream<Arguments> provideInvalidDurations() {
+        return Stream.of(
+                Arguments.of(List.of(), "주기는 최소 1개 이상이어야 합니다."),
+                Arguments.of(List.of("PT5M"), "주기는 10분 단위여야 합니다."),
+                Arguments.of(List.of("P366D"), "주기는 최대 1년 이내여야 합니다.")
+        );
+    }
+
+    @Test
+    @DisplayName("CycleDurations를 생성할 수 있다")
+    void create() {
+        // given
+        final List<CycleOptionDuration> durations = List.of(
+                CycleOptionDuration.of(cycleOption, Duration.ofMinutes(10)),
+                CycleOptionDuration.of(cycleOption, Duration.ofDays(1))
+        );
+
+        // when
+        final CycleDurations actual = new CycleDurations(durations);
+
+        // then
+        assertThat(actual.getValues()).hasSize(2);
+    }
+
+    @ParameterizedTest(name = "{1}")
+    @MethodSource("provideInvalidDurations")
+    @DisplayName("유효하지 않은 주기로 생성 시 예외를 던진다")
+    void create_invalid(List<String> durationStrings, String errorMessage) {
+        // given
+        final List<CycleOptionDuration> durations = durationStrings.stream()
+                .map(d -> CycleOptionDuration.of(cycleOption, Duration.parse(d)))
+                .toList();
+
+        // when
+        // then
+        assertThatThrownBy(() -> new CycleDurations(durations))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(errorMessage);
+    }
+}

--- a/src/test/java/com/recyclestudy/cycle/domain/CycleOptionDurationIdTest.java
+++ b/src/test/java/com/recyclestudy/cycle/domain/CycleOptionDurationIdTest.java
@@ -18,7 +18,7 @@ class CycleOptionDurationIdTest {
 
     private static Stream<Arguments> provideInvalidValue() {
         final Member member = Member.withoutId(Email.from("test@test.com"));
-        final CycleOption cycleOption = CycleOption.withoutId(member, CycleOptionTitle.from("title"), OptionType.CUSTOM,
+        final CycleOption cycleOption = CycleOption.withoutId(member, CycleOptionTitle.from("title"),
                 List.of(Duration.ofMinutes(10)));
         final Duration duration = Duration.ofMinutes(10);
 
@@ -36,7 +36,6 @@ class CycleOptionDurationIdTest {
         final CycleOption cycleOption = CycleOption.withoutId(
                 member,
                 CycleOptionTitle.from("title"),
-                OptionType.CUSTOM,
                 List.of(Duration.ofMinutes(10))
         );
         final Duration duration = Duration.ofMinutes(10);

--- a/src/test/java/com/recyclestudy/cycle/domain/CycleOptionDurationIdTest.java
+++ b/src/test/java/com/recyclestudy/cycle/domain/CycleOptionDurationIdTest.java
@@ -1,0 +1,57 @@
+package com.recyclestudy.cycle.domain;
+
+import com.recyclestudy.member.domain.Email;
+import com.recyclestudy.member.domain.Member;
+import java.time.Duration;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+class CycleOptionDurationIdTest {
+
+    private static Stream<Arguments> provideInvalidValue() {
+        final Member member = Member.withoutId(Email.from("test@test.com"));
+        final CycleOption cycleOption = CycleOption.withoutId(member, CycleOptionTitle.from("title"), OptionType.CUSTOM);
+        final Duration duration = Duration.ofMinutes(10);
+
+        return Stream.of(
+                Arguments.of(null, duration),
+                Arguments.of(cycleOption, null)
+        );
+    }
+
+    @Test
+    @DisplayName("of 메서드를 통해 CycleOptionDurationId를 생성할 수 있다")
+    void of() {
+        // given
+        final Member member = Member.withoutId(Email.from("test@test.com"));
+        final CycleOption cycleOption = CycleOption.withoutId(member, CycleOptionTitle.from("title"), OptionType.CUSTOM);
+        final Duration duration = Duration.ofMinutes(10);
+
+        // when
+        final CycleOptionDurationId actual = CycleOptionDurationId.of(cycleOption, duration);
+
+        // then
+        assertSoftly(softAssertions -> {
+            softAssertions.assertThat(actual.getCycleOption()).isEqualTo(cycleOption);
+            softAssertions.assertThat(actual.getDuration()).isEqualTo(duration);
+        });
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidValue")
+    @DisplayName("생성 시 필수값이 null이면 예외를 던진다")
+    void throwExceptionWhenNull(final CycleOption cycleOption, final Duration duration) {
+        // given
+        // when
+        // then
+        assertThatThrownBy(() -> CycleOptionDurationId.of(cycleOption, duration))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/recyclestudy/cycle/domain/CycleOptionDurationIdTest.java
+++ b/src/test/java/com/recyclestudy/cycle/domain/CycleOptionDurationIdTest.java
@@ -3,6 +3,7 @@ package com.recyclestudy.cycle.domain;
 import com.recyclestudy.member.domain.Email;
 import com.recyclestudy.member.domain.Member;
 import java.time.Duration;
+import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,7 +18,8 @@ class CycleOptionDurationIdTest {
 
     private static Stream<Arguments> provideInvalidValue() {
         final Member member = Member.withoutId(Email.from("test@test.com"));
-        final CycleOption cycleOption = CycleOption.withoutId(member, CycleOptionTitle.from("title"), OptionType.CUSTOM);
+        final CycleOption cycleOption = CycleOption.withoutId(member, CycleOptionTitle.from("title"), OptionType.CUSTOM,
+                List.of(Duration.ofMinutes(10)));
         final Duration duration = Duration.ofMinutes(10);
 
         return Stream.of(
@@ -27,11 +29,16 @@ class CycleOptionDurationIdTest {
     }
 
     @Test
-    @DisplayName("of 메서드를 통해 CycleOptionDurationId를 생성할 수 있다")
+    @DisplayName("withoutId 메서드를 통해 CycleOptionDurationId를 생성할 수 있다")
     void of() {
         // given
         final Member member = Member.withoutId(Email.from("test@test.com"));
-        final CycleOption cycleOption = CycleOption.withoutId(member, CycleOptionTitle.from("title"), OptionType.CUSTOM);
+        final CycleOption cycleOption = CycleOption.withoutId(
+                member,
+                CycleOptionTitle.from("title"),
+                OptionType.CUSTOM,
+                List.of(Duration.ofMinutes(10))
+        );
         final Duration duration = Duration.ofMinutes(10);
 
         // when

--- a/src/test/java/com/recyclestudy/cycle/domain/CycleOptionDurationTest.java
+++ b/src/test/java/com/recyclestudy/cycle/domain/CycleOptionDurationTest.java
@@ -3,6 +3,7 @@ package com.recyclestudy.cycle.domain;
 import com.recyclestudy.member.domain.Email;
 import com.recyclestudy.member.domain.Member;
 import java.time.Duration;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -11,11 +12,12 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 class CycleOptionDurationTest {
 
     @Test
-    @DisplayName("of 메서드를 통해 CycleOptionDuration을 생성할 수 있다")
+    @DisplayName("withoutId 메서드를 통해 CycleOptionDuration을 생성할 수 있다")
     void of() {
         // given
         final Member member = Member.withoutId(Email.from("test@test.com"));
-        final CycleOption cycleOption = CycleOption.withoutId(member, CycleOptionTitle.from("title"), OptionType.CUSTOM);
+        final CycleOption cycleOption = CycleOption.withoutId(member, CycleOptionTitle.from("title"), OptionType.CUSTOM,
+                List.of(Duration.ofMinutes(10)));
         final Duration duration = Duration.ofMinutes(10);
 
         // when

--- a/src/test/java/com/recyclestudy/cycle/domain/CycleOptionDurationTest.java
+++ b/src/test/java/com/recyclestudy/cycle/domain/CycleOptionDurationTest.java
@@ -1,0 +1,30 @@
+package com.recyclestudy.cycle.domain;
+
+import com.recyclestudy.member.domain.Email;
+import com.recyclestudy.member.domain.Member;
+import java.time.Duration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+class CycleOptionDurationTest {
+
+    @Test
+    @DisplayName("of 메서드를 통해 CycleOptionDuration을 생성할 수 있다")
+    void of() {
+        // given
+        final Member member = Member.withoutId(Email.from("test@test.com"));
+        final CycleOption cycleOption = CycleOption.withoutId(member, CycleOptionTitle.from("title"), OptionType.CUSTOM);
+        final Duration duration = Duration.ofMinutes(10);
+
+        // when
+        final CycleOptionDuration actual = CycleOptionDuration.of(cycleOption, duration);
+
+        // then
+        assertSoftly(softAssertions -> {
+            softAssertions.assertThat(actual.getId().getCycleOption()).isEqualTo(cycleOption);
+            softAssertions.assertThat(actual.getId().getDuration()).isEqualTo(duration);
+        });
+    }
+}

--- a/src/test/java/com/recyclestudy/cycle/domain/CycleOptionDurationTest.java
+++ b/src/test/java/com/recyclestudy/cycle/domain/CycleOptionDurationTest.java
@@ -16,7 +16,7 @@ class CycleOptionDurationTest {
     void of() {
         // given
         final Member member = Member.withoutId(Email.from("test@test.com"));
-        final CycleOption cycleOption = CycleOption.withoutId(member, CycleOptionTitle.from("title"), OptionType.CUSTOM,
+        final CycleOption cycleOption = CycleOption.withoutId(member, CycleOptionTitle.from("title"),
                 List.of(Duration.ofMinutes(10)));
         final Duration duration = Duration.ofMinutes(10);
 

--- a/src/test/java/com/recyclestudy/cycle/domain/CycleOptionTest.java
+++ b/src/test/java/com/recyclestudy/cycle/domain/CycleOptionTest.java
@@ -16,23 +16,33 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 class CycleOptionTest {
 
+    private static Stream<Arguments> provideInvalidValue() {
+        final Member member = Member.withoutId(Email.from("test@test.com"));
+        final CycleOptionTitle title = CycleOptionTitle.from("title");
+        final List<Duration> durations = List.of(Duration.ofMinutes(10));
+
+        return Stream.of(
+                Arguments.of(null, title, durations),
+                Arguments.of(member, null, durations),
+                Arguments.of(member, title, null)
+        );
+    }
+
     @Test
     @DisplayName("withoutId 메서드를 통해 CycleOption을 생성할 수 있다")
     void withoutId() {
         // given
         final Member member = Member.withoutId(Email.from("test@test.com"));
         final CycleOptionTitle title = CycleOptionTitle.from("title");
-        final OptionType optionType = OptionType.CUSTOM;
         final List<Duration> durations = List.of(Duration.ofMinutes(10), Duration.ofDays(1));
 
         // when
-        final CycleOption actual = CycleOption.withoutId(member, title, optionType, durations);
+        final CycleOption actual = CycleOption.withoutId(member, title, durations);
 
         // then
         assertSoftly(softAssertions -> {
             softAssertions.assertThat(actual.getMember()).isEqualTo(member);
             softAssertions.assertThat(actual.getTitle()).isEqualTo(title);
-            softAssertions.assertThat(actual.getOptionType()).isEqualTo(optionType);
             softAssertions.assertThat(actual.getDurations()).hasSize(2);
         });
     }
@@ -43,27 +53,12 @@ class CycleOptionTest {
     void throwExceptionWhenNull(
             final Member member,
             final CycleOptionTitle title,
-            final OptionType optionType,
             final List<Duration> durations
     ) {
         // given
         // when
         // then
-        assertThatThrownBy(() -> CycleOption.withoutId(member, title, optionType, durations))
+        assertThatThrownBy(() -> CycleOption.withoutId(member, title, durations))
                 .isInstanceOf(IllegalArgumentException.class);
-    }
-
-    private static Stream<Arguments> provideInvalidValue() {
-        final Member member = Member.withoutId(Email.from("test@test.com"));
-        final CycleOptionTitle title = CycleOptionTitle.from("title");
-        final OptionType optionType = OptionType.CUSTOM;
-        final List<Duration> durations = List.of(Duration.ofMinutes(10));
-
-        return Stream.of(
-                Arguments.of(null, title, optionType, durations),
-                Arguments.of(member, null, optionType, durations),
-                Arguments.of(member, title, null, durations),
-                Arguments.of(member, title, optionType, null)
-        );
     }
 }

--- a/src/test/java/com/recyclestudy/cycle/domain/CycleOptionTest.java
+++ b/src/test/java/com/recyclestudy/cycle/domain/CycleOptionTest.java
@@ -1,0 +1,63 @@
+package com.recyclestudy.cycle.domain;
+
+import com.recyclestudy.member.domain.Email;
+import com.recyclestudy.member.domain.Member;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+class CycleOptionTest {
+
+    private static Stream<Arguments> provideInvalidValue() {
+        final Member member = Member.withoutId(Email.from("test@test.com"));
+        final CycleOptionTitle title = CycleOptionTitle.from("title");
+        final OptionType optionType = OptionType.CUSTOM;
+
+        return Stream.of(
+                Arguments.of(null, title, optionType),
+                Arguments.of(member, null, optionType),
+                Arguments.of(member, title, null)
+        );
+    }
+
+    @Test
+    @DisplayName("withoutId 메서드를 통해 CycleOption을 생성할 수 있다")
+    void withoutId() {
+        // given
+        final Member member = Member.withoutId(Email.from("test@test.com"));
+        final CycleOptionTitle title = CycleOptionTitle.from("title");
+        final OptionType optionType = OptionType.CUSTOM;
+
+        // when
+        final CycleOption actual = CycleOption.withoutId(member, title, optionType);
+
+        // then
+        assertSoftly(softAssertions -> {
+            softAssertions.assertThat(actual.getMember()).isEqualTo(member);
+            softAssertions.assertThat(actual.getTitle()).isEqualTo(title);
+            softAssertions.assertThat(actual.getOptionType()).isEqualTo(optionType);
+            softAssertions.assertThat(actual.getDurations()).isEmpty();
+        });
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidValue")
+    @DisplayName("생성 시 필수값이 null이면 예외를 던진다")
+    void throwExceptionWhenNull(
+            final Member member,
+            final CycleOptionTitle title,
+            final OptionType optionType
+    ) {
+        // given
+        // when
+        // then
+        assertThatThrownBy(() -> CycleOption.withoutId(member, title, optionType))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/recyclestudy/cycle/domain/CycleOptionTest.java
+++ b/src/test/java/com/recyclestudy/cycle/domain/CycleOptionTest.java
@@ -2,6 +2,8 @@ package com.recyclestudy.cycle.domain;
 
 import com.recyclestudy.member.domain.Email;
 import com.recyclestudy.member.domain.Member;
+import java.time.Duration;
+import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,18 +16,6 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 class CycleOptionTest {
 
-    private static Stream<Arguments> provideInvalidValue() {
-        final Member member = Member.withoutId(Email.from("test@test.com"));
-        final CycleOptionTitle title = CycleOptionTitle.from("title");
-        final OptionType optionType = OptionType.CUSTOM;
-
-        return Stream.of(
-                Arguments.of(null, title, optionType),
-                Arguments.of(member, null, optionType),
-                Arguments.of(member, title, null)
-        );
-    }
-
     @Test
     @DisplayName("withoutId 메서드를 통해 CycleOption을 생성할 수 있다")
     void withoutId() {
@@ -33,16 +23,17 @@ class CycleOptionTest {
         final Member member = Member.withoutId(Email.from("test@test.com"));
         final CycleOptionTitle title = CycleOptionTitle.from("title");
         final OptionType optionType = OptionType.CUSTOM;
+        final List<Duration> durations = List.of(Duration.ofMinutes(10), Duration.ofDays(1));
 
         // when
-        final CycleOption actual = CycleOption.withoutId(member, title, optionType);
+        final CycleOption actual = CycleOption.withoutId(member, title, optionType, durations);
 
         // then
         assertSoftly(softAssertions -> {
             softAssertions.assertThat(actual.getMember()).isEqualTo(member);
             softAssertions.assertThat(actual.getTitle()).isEqualTo(title);
             softAssertions.assertThat(actual.getOptionType()).isEqualTo(optionType);
-            softAssertions.assertThat(actual.getDurations()).isEmpty();
+            softAssertions.assertThat(actual.getDurations()).hasSize(2);
         });
     }
 
@@ -52,12 +43,27 @@ class CycleOptionTest {
     void throwExceptionWhenNull(
             final Member member,
             final CycleOptionTitle title,
-            final OptionType optionType
+            final OptionType optionType,
+            final List<Duration> durations
     ) {
         // given
         // when
         // then
-        assertThatThrownBy(() -> CycleOption.withoutId(member, title, optionType))
+        assertThatThrownBy(() -> CycleOption.withoutId(member, title, optionType, durations))
                 .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static Stream<Arguments> provideInvalidValue() {
+        final Member member = Member.withoutId(Email.from("test@test.com"));
+        final CycleOptionTitle title = CycleOptionTitle.from("title");
+        final OptionType optionType = OptionType.CUSTOM;
+        final List<Duration> durations = List.of(Duration.ofMinutes(10));
+
+        return Stream.of(
+                Arguments.of(null, title, optionType, durations),
+                Arguments.of(member, null, optionType, durations),
+                Arguments.of(member, title, null, durations),
+                Arguments.of(member, title, optionType, null)
+        );
     }
 }

--- a/src/test/java/com/recyclestudy/cycle/domain/CycleOptionTitleTest.java
+++ b/src/test/java/com/recyclestudy/cycle/domain/CycleOptionTitleTest.java
@@ -1,0 +1,31 @@
+package com.recyclestudy.cycle.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CycleOptionTitleTest {
+
+    @Test
+    @DisplayName("from 메서드를 통해 CycleOptionTitle을 생성할 수 있다")
+    void from() {
+        // given
+        final String value = "title";
+
+        // when
+        final CycleOptionTitle actual = CycleOptionTitle.from(value);
+
+        // then
+        assertThat(actual.getValue()).isEqualTo(value);
+    }
+
+    @Test
+    @DisplayName("null로 생성 시도 시, 예외를 던진다")
+    void throwExceptionWhenNull() {
+        // when & then
+        assertThatThrownBy(() -> CycleOptionTitle.from(null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/recyclestudy/cycle/domain/selection/CustomCycleSelectionTest.java
+++ b/src/test/java/com/recyclestudy/cycle/domain/selection/CustomCycleSelectionTest.java
@@ -1,0 +1,39 @@
+package com.recyclestudy.cycle.domain.selection;
+
+import com.recyclestudy.exception.BadRequestException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CustomCycleSelectionTest {
+
+    @Test
+    @DisplayName("유효한 ID로 생성할 수 있다")
+    void create() {
+        // given
+        final Long id = 1L;
+
+        // when
+        final CustomCycleSelection selection = new CustomCycleSelection(id);
+
+        // then
+        assertThat(selection.id()).isEqualTo(id);
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(longs = {0, -1, -100})
+    @DisplayName("유효하지 않은 ID로 생성 시 예외를 던진다")
+    void create_invalidId(final Long invalidId) {
+        // when
+        // then
+        assertThatThrownBy(() -> new CustomCycleSelection(invalidId))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("유효하지 않은 커스텀 주기 ID입니다");
+    }
+}

--- a/src/test/java/com/recyclestudy/cycle/domain/selection/DefaultCycleSelectionTest.java
+++ b/src/test/java/com/recyclestudy/cycle/domain/selection/DefaultCycleSelectionTest.java
@@ -1,0 +1,37 @@
+package com.recyclestudy.cycle.domain.selection;
+
+import com.recyclestudy.exception.BadRequestException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DefaultCycleSelectionTest {
+
+    @Test
+    @DisplayName("유효한 기본 주기 코드로 생성할 수 있다")
+    void create() {
+        // given
+        final String code = "EBBINGHAUS";
+
+        // when
+        final DefaultCycleSelection selection = new DefaultCycleSelection(code);
+
+        // then
+        assertThat(selection.code()).isEqualTo(code);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 기본 주기 코드로 생성 시 예외를 던진다")
+    void create_invalidCode() {
+        // given
+        final String invalidCode = "INVALID_CODE";
+
+        // when
+        // then
+        assertThatThrownBy(() -> new DefaultCycleSelection(invalidCode))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("존재하지 않는 기본 주기입니다");
+    }
+}

--- a/src/test/java/com/recyclestudy/cycle/service/CycleOptionServiceTest.java
+++ b/src/test/java/com/recyclestudy/cycle/service/CycleOptionServiceTest.java
@@ -51,8 +51,8 @@ class CycleOptionServiceTest {
     private static Stream<Arguments> provideInvalidDurations() {
         return Stream.of(
                 Arguments.of(List.of(), "주기는 최소 1개 이상이어야 합니다."),
-                Arguments.of(List.of("PT5M"), "주기는 10분 단위여야 합니다."),
-                Arguments.of(List.of("P366D"), "주기는 최대 1년 이내여야 합니다.")
+                Arguments.of(List.of(Duration.ofMinutes(5)), "주기는 10분 단위여야 합니다."),
+                Arguments.of(List.of(Duration.ofDays(366)), "주기는 최대 1년 이내여야 합니다.")
         );
     }
 
@@ -105,7 +105,10 @@ class CycleOptionServiceTest {
         // given
         final DeviceIdentifier identifier = DeviceIdentifier.from("device-id");
         final Member member = Member.withoutId(Email.from("test@test.com"));
-        final CycleOptionSaveInput input = CycleOptionSaveInput.of("title", List.of("PT10M", "PT1H"));
+        final CycleOptionSaveInput input = new CycleOptionSaveInput(
+                CycleOptionTitle.from("title"),
+                List.of(Duration.ofMinutes(10), Duration.ofHours(1))
+        );
 
         given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.of(member));
         given(cycleOptionRepository.countByMember(member)).willReturn(0L);
@@ -116,7 +119,7 @@ class CycleOptionServiceTest {
 
         // then
         assertSoftly(softAssertions -> {
-            softAssertions.assertThat(actual.title()).isEqualTo(input.title());
+            softAssertions.assertThat(actual.title().getValue()).isEqualTo(input.title().getValue());
             softAssertions.assertThat(actual.durations()).hasSize(2);
             softAssertions.assertThat(actual.durations().get(0)).isEqualTo(Duration.ofMinutes(10));
             softAssertions.assertThat(actual.durations().get(1)).isEqualTo(Duration.ofHours(1));
@@ -129,7 +132,10 @@ class CycleOptionServiceTest {
         // given
         final DeviceIdentifier identifier = DeviceIdentifier.from("device-id");
         final Member member = Member.withoutId(Email.from("test@test.com"));
-        final CycleOptionSaveInput input = CycleOptionSaveInput.of("title", List.of("PT10M"));
+        final CycleOptionSaveInput input = new CycleOptionSaveInput(
+                CycleOptionTitle.from("title"),
+                List.of(Duration.ofMinutes(10))
+        );
 
         given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.of(member));
         given(cycleOptionRepository.countByMember(member)).willReturn(5L);
@@ -144,11 +150,11 @@ class CycleOptionServiceTest {
     @ParameterizedTest(name = "{1}")
     @MethodSource("provideInvalidDurations")
     @DisplayName("주기 시간 간격이 유효하지 않으면 예외를 던진다")
-    void saveCycleOption_invalidDuration(List<String> durationStrings, String errorMessage) {
+    void saveCycleOption_invalidDuration(List<Duration> durations, String errorMessage) {
         // given
         final DeviceIdentifier identifier = DeviceIdentifier.from("device-id");
         final Member member = Member.withoutId(Email.from("test@test.com"));
-        final CycleOptionSaveInput input = CycleOptionSaveInput.of("title", durationStrings);
+        final CycleOptionSaveInput input = new CycleOptionSaveInput(CycleOptionTitle.from("title"), durations);
 
         given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.of(member));
         given(cycleOptionRepository.countByMember(member)).willReturn(0L);
@@ -175,7 +181,10 @@ class CycleOptionServiceTest {
         );
         ReflectionTestUtils.setField(cycleOption, "id", 1L);
 
-        final CycleOptionUpdateInput input = CycleOptionUpdateInput.of("new title", List.of("PT20M"));
+        final CycleOptionUpdateInput input = new CycleOptionUpdateInput(
+                CycleOptionTitle.from("new title"),
+                List.of(Duration.ofMinutes(20))
+        );
 
         given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.of(member));
         given(cycleOptionRepository.findByIdWithDurations(1L)).willReturn(Optional.of(cycleOption));
@@ -207,7 +216,10 @@ class CycleOptionServiceTest {
                 CycleOptionTitle.from("title"),
                 List.of(Duration.ofMinutes(10))
         );
-        final CycleOptionUpdateInput input = CycleOptionUpdateInput.of("new title", List.of("PT20M"));
+        final CycleOptionUpdateInput input = new CycleOptionUpdateInput(
+                CycleOptionTitle.from("new title"),
+                List.of(Duration.ofMinutes(20))
+        );
 
         given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.of(other));
         given(cycleOptionRepository.findByIdWithDurations(1L)).willReturn(Optional.of(cycleOption));

--- a/src/test/java/com/recyclestudy/cycle/service/CycleOptionServiceTest.java
+++ b/src/test/java/com/recyclestudy/cycle/service/CycleOptionServiceTest.java
@@ -1,0 +1,79 @@
+package com.recyclestudy.cycle.service;
+
+import com.recyclestudy.cycle.domain.CycleOption;
+import com.recyclestudy.cycle.domain.CycleOptionDuration;
+import com.recyclestudy.cycle.domain.CycleOptionTitle;
+import com.recyclestudy.cycle.domain.OptionType;
+import com.recyclestudy.cycle.repository.CycleOptionRepository;
+import com.recyclestudy.cycle.service.output.CycleOptionFindOutput;
+import com.recyclestudy.exception.UnauthorizedException;
+import com.recyclestudy.member.domain.DeviceIdentifier;
+import com.recyclestudy.member.domain.Email;
+import com.recyclestudy.member.domain.Member;
+import com.recyclestudy.member.repository.MemberRepository;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class CycleOptionServiceTest {
+
+    @Mock
+    MemberRepository memberRepository;
+
+    @Mock
+    CycleOptionRepository cycleOptionRepository;
+
+    @InjectMocks
+    CycleOptionService cycleOptionService;
+
+    @Test
+    @DisplayName("멤버가 가진 주기 옵션을 조회할 수 있다")
+    void findAllCycleOptions() {
+        // given
+        final DeviceIdentifier identifier = DeviceIdentifier.from("device-id");
+        final Member member = Member.withoutId(Email.from("test@test.com"));
+        final CycleOption cycleOption = CycleOption.withoutId(member, CycleOptionTitle.from("title"),
+                OptionType.CUSTOM);
+        cycleOption.getDurations().add(CycleOptionDuration.of(cycleOption, Duration.ofMinutes(10)));
+
+        given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.of(member));
+        given(cycleOptionRepository.findAllByMember(member)).willReturn(List.of(cycleOption));
+
+        // when
+        final CycleOptionFindOutput actual = cycleOptionService.findAllCycleOptions(identifier);
+
+        // then
+        assertSoftly(softAssertions -> {
+            softAssertions.assertThat(actual.options()).hasSize(1);
+            softAssertions.assertThat(actual.options().getFirst().title().getValue()).isEqualTo("title");
+            softAssertions.assertThat(actual.options().getFirst().durations()).hasSize(1);
+            softAssertions.assertThat(actual.options().getFirst().durations().getFirst())
+                    .isEqualTo(Duration.ofMinutes(10));
+        });
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 디바이스로 조회 시 예외를 던진다")
+    void findAllCycleOptions_unauthorized() {
+        // given
+        final DeviceIdentifier identifier = DeviceIdentifier.from("device-id");
+
+        given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.empty());
+
+        // when
+        // then
+        assertThatThrownBy(() -> cycleOptionService.findAllCycleOptions(identifier))
+                .isInstanceOf(UnauthorizedException.class);
+    }
+}

--- a/src/test/java/com/recyclestudy/cycle/service/CycleOptionServiceTest.java
+++ b/src/test/java/com/recyclestudy/cycle/service/CycleOptionServiceTest.java
@@ -6,9 +6,12 @@ import com.recyclestudy.cycle.domain.CycleOptionTitle;
 import com.recyclestudy.cycle.domain.OptionType;
 import com.recyclestudy.cycle.repository.CycleOptionRepository;
 import com.recyclestudy.cycle.service.input.CycleOptionSaveInput;
+import com.recyclestudy.cycle.service.input.CycleOptionUpdateInput;
 import com.recyclestudy.cycle.service.output.CycleOptionFindOutput;
 import com.recyclestudy.cycle.service.output.CycleOptionSaveOutput;
 import com.recyclestudy.exception.BadRequestException;
+import com.recyclestudy.exception.ForbiddenException;
+import com.recyclestudy.exception.NotFoundException;
 import com.recyclestudy.exception.UnauthorizedException;
 import com.recyclestudy.member.domain.DeviceIdentifier;
 import com.recyclestudy.member.domain.Email;
@@ -27,11 +30,13 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class CycleOptionServiceTest {
@@ -51,9 +56,12 @@ class CycleOptionServiceTest {
         // given
         final DeviceIdentifier identifier = DeviceIdentifier.from("device-id");
         final Member member = Member.withoutId(Email.from("test@test.com"));
-        final CycleOption cycleOption = CycleOption.withoutId(member, CycleOptionTitle.from("title"),
-                OptionType.CUSTOM);
-        cycleOption.getDurations().add(CycleOptionDuration.of(cycleOption, Duration.ofMinutes(10)));
+        final CycleOption cycleOption = CycleOption.withoutId(
+                member,
+                CycleOptionTitle.from("title"),
+                OptionType.CUSTOM,
+                List.of(Duration.ofMinutes(10))
+        );
 
         given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.of(member));
         given(cycleOptionRepository.findAllByMember(member)).willReturn(List.of(cycleOption));
@@ -118,11 +126,11 @@ class CycleOptionServiceTest {
         final CycleOptionSaveInput input = CycleOptionSaveInput.of("title", List.of("PT10M"));
 
         final List<CycleOption> existingOptions = List.of(
-                CycleOption.withoutId(member, CycleOptionTitle.from("1"), OptionType.CUSTOM),
-                CycleOption.withoutId(member, CycleOptionTitle.from("2"), OptionType.CUSTOM),
-                CycleOption.withoutId(member, CycleOptionTitle.from("3"), OptionType.CUSTOM),
-                CycleOption.withoutId(member, CycleOptionTitle.from("4"), OptionType.CUSTOM),
-                CycleOption.withoutId(member, CycleOptionTitle.from("5"), OptionType.CUSTOM)
+                CycleOption.withoutId(member, CycleOptionTitle.from("1"), OptionType.CUSTOM, List.of(Duration.ofMinutes(10))),
+                CycleOption.withoutId(member, CycleOptionTitle.from("2"), OptionType.CUSTOM, List.of(Duration.ofMinutes(10))),
+                CycleOption.withoutId(member, CycleOptionTitle.from("3"), OptionType.CUSTOM, List.of(Duration.ofMinutes(10))),
+                CycleOption.withoutId(member, CycleOptionTitle.from("4"), OptionType.CUSTOM, List.of(Duration.ofMinutes(10))),
+                CycleOption.withoutId(member, CycleOptionTitle.from("5"), OptionType.CUSTOM, List.of(Duration.ofMinutes(10)))
         );
 
         given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.of(member));
@@ -160,5 +168,118 @@ class CycleOptionServiceTest {
         assertThatThrownBy(() -> cycleOptionService.saveCycleOption(identifier, input))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(errorMessage);
+    }
+
+    @Test
+    @DisplayName("커스텀 주기 옵션을 수정할 수 있다")
+    void updateCycleOption() {
+        // given
+        final DeviceIdentifier identifier = DeviceIdentifier.from("device-id");
+        final Member member = Member.withoutId(Email.from("test@test.com"));
+        ReflectionTestUtils.setField(member, "id", 1L);
+
+        final CycleOption cycleOption = CycleOption.withoutId(
+                member,
+                CycleOptionTitle.from("old"),
+                OptionType.CUSTOM,
+                List.of(Duration.ofMinutes(10))
+        );
+        ReflectionTestUtils.setField(cycleOption, "id", 1L);
+
+        final CycleOptionUpdateInput input = CycleOptionUpdateInput.of("new title", List.of("PT20M"));
+
+        given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.of(member));
+        given(cycleOptionRepository.findById(1L)).willReturn(Optional.of(cycleOption));
+
+        // when
+        final CycleOptionSaveOutput actual = cycleOptionService.updateCycleOption(identifier, 1L, input);
+
+        // then
+        assertSoftly(softAssertions -> {
+            softAssertions.assertThat(actual.title().getValue()).isEqualTo("new title");
+            softAssertions.assertThat(actual.durations()).hasSize(1);
+            softAssertions.assertThat(actual.durations().get(0)).isEqualTo(Duration.ofMinutes(20));
+        });
+    }
+
+    @Test
+    @DisplayName("소유자가 아닌 경우 수정 시 예외를 던진다")
+    void updateCycleOption_forbidden() {
+        // given
+        final DeviceIdentifier identifier = DeviceIdentifier.from("device-id");
+        final Member owner = Member.withoutId(Email.from("owner@test.com"));
+        ReflectionTestUtils.setField(owner, "id", 1L);
+
+        final Member other = Member.withoutId(Email.from("other@test.com"));
+        ReflectionTestUtils.setField(other, "id", 2L);
+
+        final CycleOption cycleOption = CycleOption.withoutId(
+                owner,
+                CycleOptionTitle.from("title"),
+                OptionType.CUSTOM,
+                List.of(Duration.ofMinutes(10))
+        );
+        final CycleOptionUpdateInput input = CycleOptionUpdateInput.of("new title", List.of("PT20M"));
+
+        given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.of(other));
+        given(cycleOptionRepository.findById(1L)).willReturn(Optional.of(cycleOption));
+
+        // when
+        // then
+        assertThatThrownBy(() -> cycleOptionService.updateCycleOption(identifier, 1L, input))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage("해당 주기 옵션에 대한 권한이 없습니다.");
+    }
+
+    @Test
+    @DisplayName("기본 주기를 수정하려는 경우 예외를 던진다")
+    void updateCycleOption_forbidden_default() {
+        // given
+        final DeviceIdentifier identifier = DeviceIdentifier.from("device-id");
+        final Member member = Member.withoutId(Email.from("test@test.com"));
+        ReflectionTestUtils.setField(member, "id", 1L);
+
+        final CycleOption cycleOption = CycleOption.withoutId(
+                member,
+                CycleOptionTitle.from("title"),
+                OptionType.DEFAULT,
+                List.of(Duration.ofMinutes(10))
+        );
+        final CycleOptionUpdateInput input = CycleOptionUpdateInput.of("new title", List.of("PT20M"));
+
+        given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.of(member));
+        given(cycleOptionRepository.findById(1L)).willReturn(Optional.of(cycleOption));
+
+        // when
+        // then
+        assertThatThrownBy(() -> cycleOptionService.updateCycleOption(identifier, 1L, input))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage("기본 주기는 수정/삭제할 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("커스텀 주기 옵션을 삭제할 수 있다")
+    void deleteCycleOption() {
+        // given
+        final DeviceIdentifier identifier = DeviceIdentifier.from("device-id");
+        final Member member = Member.withoutId(Email.from("test@test.com"));
+        ReflectionTestUtils.setField(member, "id", 1L);
+
+        final CycleOption cycleOption = CycleOption.withoutId(
+                member,
+                CycleOptionTitle.from("title"),
+                OptionType.CUSTOM,
+                List.of(Duration.ofMinutes(10))
+        );
+        ReflectionTestUtils.setField(cycleOption, "id", 1L);
+
+        given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.of(member));
+        given(cycleOptionRepository.findById(1L)).willReturn(Optional.of(cycleOption));
+
+        // when
+        cycleOptionService.deleteCycleOption(identifier, 1L);
+
+        // then
+        verify(cycleOptionRepository).delete(cycleOption);
     }
 }

--- a/src/test/java/com/recyclestudy/cycle/service/CycleOptionServiceTest.java
+++ b/src/test/java/com/recyclestudy/cycle/service/CycleOptionServiceTest.java
@@ -1,16 +1,14 @@
 package com.recyclestudy.cycle.service;
 
 import com.recyclestudy.cycle.domain.CycleOption;
-import com.recyclestudy.cycle.domain.CycleOptionDuration;
 import com.recyclestudy.cycle.domain.CycleOptionTitle;
-import com.recyclestudy.cycle.domain.OptionType;
+import com.recyclestudy.cycle.domain.DefaultCycleOption;
 import com.recyclestudy.cycle.repository.CycleOptionRepository;
 import com.recyclestudy.cycle.service.input.CycleOptionSaveInput;
 import com.recyclestudy.cycle.service.input.CycleOptionUpdateInput;
 import com.recyclestudy.cycle.service.output.CycleOptionFindOutput;
 import com.recyclestudy.cycle.service.output.CycleOptionSaveOutput;
 import com.recyclestudy.exception.BadRequestException;
-import com.recyclestudy.exception.ForbiddenException;
 import com.recyclestudy.exception.NotFoundException;
 import com.recyclestudy.exception.UnauthorizedException;
 import com.recyclestudy.member.domain.DeviceIdentifier;
@@ -50,6 +48,14 @@ class CycleOptionServiceTest {
     @InjectMocks
     CycleOptionService cycleOptionService;
 
+    private static Stream<Arguments> provideInvalidDurations() {
+        return Stream.of(
+                Arguments.of(List.of(), "주기는 최소 1개 이상이어야 합니다."),
+                Arguments.of(List.of("PT5M"), "주기는 10분 단위여야 합니다."),
+                Arguments.of(List.of("P366D"), "주기는 최대 1년 이내여야 합니다.")
+        );
+    }
+
     @Test
     @DisplayName("멤버가 가진 주기 옵션을 조회할 수 있다")
     void findAllCycleOptions() {
@@ -58,8 +64,7 @@ class CycleOptionServiceTest {
         final Member member = Member.withoutId(Email.from("test@test.com"));
         final CycleOption cycleOption = CycleOption.withoutId(
                 member,
-                CycleOptionTitle.from("title"),
-                OptionType.CUSTOM,
+                CycleOptionTitle.from("custom title"),
                 List.of(Duration.ofMinutes(10))
         );
 
@@ -71,10 +76,11 @@ class CycleOptionServiceTest {
 
         // then
         assertSoftly(softAssertions -> {
-            softAssertions.assertThat(actual.options()).hasSize(1);
-            softAssertions.assertThat(actual.options().getFirst().title().getValue()).isEqualTo("title");
-            softAssertions.assertThat(actual.options().getFirst().durations()).hasSize(1);
-            softAssertions.assertThat(actual.options().getFirst().durations().getFirst())
+            softAssertions.assertThat(actual.defaultOptions()).hasSize(DefaultCycleOption.getAll().size());
+            softAssertions.assertThat(actual.customOptions()).hasSize(1);
+            softAssertions.assertThat(actual.customOptions().getFirst().title()).isEqualTo("custom title");
+            softAssertions.assertThat(actual.customOptions().getFirst().durations()).hasSize(1);
+            softAssertions.assertThat(actual.customOptions().getFirst().durations().getFirst())
                     .isEqualTo(Duration.ofMinutes(10));
         });
     }
@@ -102,7 +108,7 @@ class CycleOptionServiceTest {
         final CycleOptionSaveInput input = CycleOptionSaveInput.of("title", List.of("PT10M", "PT1H"));
 
         given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.of(member));
-        given(cycleOptionRepository.findAllByMember(member)).willReturn(List.of());
+        given(cycleOptionRepository.countByMember(member)).willReturn(0L);
         given(cycleOptionRepository.save(any(CycleOption.class))).willAnswer(invocation -> invocation.getArgument(0));
 
         // when
@@ -125,30 +131,14 @@ class CycleOptionServiceTest {
         final Member member = Member.withoutId(Email.from("test@test.com"));
         final CycleOptionSaveInput input = CycleOptionSaveInput.of("title", List.of("PT10M"));
 
-        final List<CycleOption> existingOptions = List.of(
-                CycleOption.withoutId(member, CycleOptionTitle.from("1"), OptionType.CUSTOM, List.of(Duration.ofMinutes(10))),
-                CycleOption.withoutId(member, CycleOptionTitle.from("2"), OptionType.CUSTOM, List.of(Duration.ofMinutes(10))),
-                CycleOption.withoutId(member, CycleOptionTitle.from("3"), OptionType.CUSTOM, List.of(Duration.ofMinutes(10))),
-                CycleOption.withoutId(member, CycleOptionTitle.from("4"), OptionType.CUSTOM, List.of(Duration.ofMinutes(10))),
-                CycleOption.withoutId(member, CycleOptionTitle.from("5"), OptionType.CUSTOM, List.of(Duration.ofMinutes(10)))
-        );
-
         given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.of(member));
-        given(cycleOptionRepository.findAllByMember(member)).willReturn(existingOptions);
+        given(cycleOptionRepository.countByMember(member)).willReturn(5L);
 
         // when
         // then
         assertThatThrownBy(() -> cycleOptionService.saveCycleOption(identifier, input))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage("커스텀 주기는 최대 5개까지만 생성 가능합니다.");
-    }
-
-    private static Stream<Arguments> provideInvalidDurations() {
-        return Stream.of(
-                Arguments.of(List.of(), "주기는 최소 1개 이상이어야 합니다."),
-                Arguments.of(List.of("PT5M"), "주기는 10분 단위여야 합니다."),
-                Arguments.of(List.of("P366D"), "주기는 최대 1년 이내여야 합니다.")
-        );
     }
 
     @ParameterizedTest(name = "{1}")
@@ -161,7 +151,7 @@ class CycleOptionServiceTest {
         final CycleOptionSaveInput input = CycleOptionSaveInput.of("title", durationStrings);
 
         given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.of(member));
-        given(cycleOptionRepository.findAllByMember(member)).willReturn(List.of());
+        given(cycleOptionRepository.countByMember(member)).willReturn(0L);
 
         // when
         // then
@@ -181,7 +171,6 @@ class CycleOptionServiceTest {
         final CycleOption cycleOption = CycleOption.withoutId(
                 member,
                 CycleOptionTitle.from("old"),
-                OptionType.CUSTOM,
                 List.of(Duration.ofMinutes(10))
         );
         ReflectionTestUtils.setField(cycleOption, "id", 1L);
@@ -189,7 +178,7 @@ class CycleOptionServiceTest {
         final CycleOptionUpdateInput input = CycleOptionUpdateInput.of("new title", List.of("PT20M"));
 
         given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.of(member));
-        given(cycleOptionRepository.findById(1L)).willReturn(Optional.of(cycleOption));
+        given(cycleOptionRepository.findByIdWithDurations(1L)).willReturn(Optional.of(cycleOption));
 
         // when
         final CycleOptionSaveOutput actual = cycleOptionService.updateCycleOption(identifier, 1L, input);
@@ -204,7 +193,7 @@ class CycleOptionServiceTest {
 
     @Test
     @DisplayName("소유자가 아닌 경우 수정 시 예외를 던진다")
-    void updateCycleOption_forbidden() {
+    void updateCycleOption_notOwner() {
         // given
         final DeviceIdentifier identifier = DeviceIdentifier.from("device-id");
         final Member owner = Member.withoutId(Email.from("owner@test.com"));
@@ -216,45 +205,18 @@ class CycleOptionServiceTest {
         final CycleOption cycleOption = CycleOption.withoutId(
                 owner,
                 CycleOptionTitle.from("title"),
-                OptionType.CUSTOM,
                 List.of(Duration.ofMinutes(10))
         );
         final CycleOptionUpdateInput input = CycleOptionUpdateInput.of("new title", List.of("PT20M"));
 
         given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.of(other));
-        given(cycleOptionRepository.findById(1L)).willReturn(Optional.of(cycleOption));
+        given(cycleOptionRepository.findByIdWithDurations(1L)).willReturn(Optional.of(cycleOption));
 
         // when
         // then
         assertThatThrownBy(() -> cycleOptionService.updateCycleOption(identifier, 1L, input))
-                .isInstanceOf(ForbiddenException.class)
-                .hasMessage("해당 주기 옵션에 대한 권한이 없습니다.");
-    }
-
-    @Test
-    @DisplayName("기본 주기를 수정하려는 경우 예외를 던진다")
-    void updateCycleOption_forbidden_default() {
-        // given
-        final DeviceIdentifier identifier = DeviceIdentifier.from("device-id");
-        final Member member = Member.withoutId(Email.from("test@test.com"));
-        ReflectionTestUtils.setField(member, "id", 1L);
-
-        final CycleOption cycleOption = CycleOption.withoutId(
-                member,
-                CycleOptionTitle.from("title"),
-                OptionType.DEFAULT,
-                List.of(Duration.ofMinutes(10))
-        );
-        final CycleOptionUpdateInput input = CycleOptionUpdateInput.of("new title", List.of("PT20M"));
-
-        given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.of(member));
-        given(cycleOptionRepository.findById(1L)).willReturn(Optional.of(cycleOption));
-
-        // when
-        // then
-        assertThatThrownBy(() -> cycleOptionService.updateCycleOption(identifier, 1L, input))
-                .isInstanceOf(ForbiddenException.class)
-                .hasMessage("기본 주기는 수정/삭제할 수 없습니다.");
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("존재하지 않는 주기 옵션입니다.");
     }
 
     @Test
@@ -268,7 +230,6 @@ class CycleOptionServiceTest {
         final CycleOption cycleOption = CycleOption.withoutId(
                 member,
                 CycleOptionTitle.from("title"),
-                OptionType.CUSTOM,
                 List.of(Duration.ofMinutes(10))
         );
         ReflectionTestUtils.setField(cycleOption, "id", 1L);

--- a/src/test/java/com/recyclestudy/cycle/service/CycleOptionServiceTest.java
+++ b/src/test/java/com/recyclestudy/cycle/service/CycleOptionServiceTest.java
@@ -5,7 +5,10 @@ import com.recyclestudy.cycle.domain.CycleOptionDuration;
 import com.recyclestudy.cycle.domain.CycleOptionTitle;
 import com.recyclestudy.cycle.domain.OptionType;
 import com.recyclestudy.cycle.repository.CycleOptionRepository;
+import com.recyclestudy.cycle.service.input.CycleOptionSaveInput;
 import com.recyclestudy.cycle.service.output.CycleOptionFindOutput;
+import com.recyclestudy.cycle.service.output.CycleOptionSaveOutput;
+import com.recyclestudy.exception.BadRequestException;
 import com.recyclestudy.exception.UnauthorizedException;
 import com.recyclestudy.member.domain.DeviceIdentifier;
 import com.recyclestudy.member.domain.Email;
@@ -14,15 +17,20 @@ import com.recyclestudy.member.repository.MemberRepository;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
@@ -75,5 +83,82 @@ class CycleOptionServiceTest {
         // then
         assertThatThrownBy(() -> cycleOptionService.findAllCycleOptions(identifier))
                 .isInstanceOf(UnauthorizedException.class);
+    }
+
+    @Test
+    @DisplayName("새로운 주기 옵션을 저장할 수 있다")
+    void saveCycleOption() {
+        // given
+        final DeviceIdentifier identifier = DeviceIdentifier.from("device-id");
+        final Member member = Member.withoutId(Email.from("test@test.com"));
+        final CycleOptionSaveInput input = CycleOptionSaveInput.of("title", List.of("PT10M", "PT1H"));
+
+        given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.of(member));
+        given(cycleOptionRepository.findAllByMember(member)).willReturn(List.of());
+        given(cycleOptionRepository.save(any(CycleOption.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        final CycleOptionSaveOutput actual = cycleOptionService.saveCycleOption(identifier, input);
+
+        // then
+        assertSoftly(softAssertions -> {
+            softAssertions.assertThat(actual.title()).isEqualTo(input.title());
+            softAssertions.assertThat(actual.durations()).hasSize(2);
+            softAssertions.assertThat(actual.durations().get(0)).isEqualTo(Duration.ofMinutes(10));
+            softAssertions.assertThat(actual.durations().get(1)).isEqualTo(Duration.ofHours(1));
+        });
+    }
+
+    @Test
+    @DisplayName("커스텀 주기가 5개 이상이면 예외를 던진다")
+    void saveCycleOption_limitExceeded() {
+        // given
+        final DeviceIdentifier identifier = DeviceIdentifier.from("device-id");
+        final Member member = Member.withoutId(Email.from("test@test.com"));
+        final CycleOptionSaveInput input = CycleOptionSaveInput.of("title", List.of("PT10M"));
+
+        final List<CycleOption> existingOptions = List.of(
+                CycleOption.withoutId(member, CycleOptionTitle.from("1"), OptionType.CUSTOM),
+                CycleOption.withoutId(member, CycleOptionTitle.from("2"), OptionType.CUSTOM),
+                CycleOption.withoutId(member, CycleOptionTitle.from("3"), OptionType.CUSTOM),
+                CycleOption.withoutId(member, CycleOptionTitle.from("4"), OptionType.CUSTOM),
+                CycleOption.withoutId(member, CycleOptionTitle.from("5"), OptionType.CUSTOM)
+        );
+
+        given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.of(member));
+        given(cycleOptionRepository.findAllByMember(member)).willReturn(existingOptions);
+
+        // when
+        // then
+        assertThatThrownBy(() -> cycleOptionService.saveCycleOption(identifier, input))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("커스텀 주기는 최대 5개까지만 생성 가능합니다.");
+    }
+
+    private static Stream<Arguments> provideInvalidDurations() {
+        return Stream.of(
+                Arguments.of(List.of(), "주기는 최소 1개 이상이어야 합니다."),
+                Arguments.of(List.of("PT5M"), "주기는 10분 단위여야 합니다."),
+                Arguments.of(List.of("P366D"), "주기는 최대 1년 이내여야 합니다.")
+        );
+    }
+
+    @ParameterizedTest(name = "{1}")
+    @MethodSource("provideInvalidDurations")
+    @DisplayName("주기 시간 간격이 유효하지 않으면 예외를 던진다")
+    void saveCycleOption_invalidDuration(List<String> durationStrings, String errorMessage) {
+        // given
+        final DeviceIdentifier identifier = DeviceIdentifier.from("device-id");
+        final Member member = Member.withoutId(Email.from("test@test.com"));
+        final CycleOptionSaveInput input = CycleOptionSaveInput.of("title", durationStrings);
+
+        given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.of(member));
+        given(cycleOptionRepository.findAllByMember(member)).willReturn(List.of());
+
+        // when
+        // then
+        assertThatThrownBy(() -> cycleOptionService.saveCycleOption(identifier, input))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(errorMessage);
     }
 }

--- a/src/test/java/com/recyclestudy/cycle/service/resolver/CustomCycleSelectionResolverTest.java
+++ b/src/test/java/com/recyclestudy/cycle/service/resolver/CustomCycleSelectionResolverTest.java
@@ -1,0 +1,82 @@
+package com.recyclestudy.cycle.service.resolver;
+
+import com.recyclestudy.cycle.domain.CycleOption;
+import com.recyclestudy.cycle.domain.CycleOptionTitle;
+import com.recyclestudy.cycle.domain.selection.CustomCycleSelection;
+import com.recyclestudy.cycle.repository.CycleOptionRepository;
+import com.recyclestudy.exception.NotFoundException;
+import com.recyclestudy.member.domain.Email;
+import com.recyclestudy.member.domain.Member;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class CustomCycleSelectionResolverTest {
+
+    @Mock
+    CycleOptionRepository cycleOptionRepository;
+
+    @InjectMocks
+    CustomCycleSelectionResolver resolver;
+
+    @Test
+    @DisplayName("지원하는 타입은 CustomCycleSelection이다")
+    void getSupportedType() {
+        // when
+        final Class<CustomCycleSelection> supportedType = resolver.getSupportedType();
+
+        // then
+        assertThat(supportedType).isEqualTo(CustomCycleSelection.class);
+    }
+
+    @Test
+    @DisplayName("커스텀 주기 선택을 resolve하면 해당 주기의 durations를 반환한다")
+    void resolve() {
+        // given
+        final Long cycleOptionId = 1L;
+        final CustomCycleSelection selection = new CustomCycleSelection(cycleOptionId);
+
+        final Member member = Member.withoutId(Email.from("test@test.com"));
+        final List<Duration> expectedDurations = List.of(Duration.ofMinutes(10), Duration.ofHours(1));
+        final CycleOption cycleOption = CycleOption.withoutId(
+                member,
+                CycleOptionTitle.from("custom"),
+                expectedDurations
+        );
+
+        given(cycleOptionRepository.findById(cycleOptionId)).willReturn(Optional.of(cycleOption));
+
+        // when
+        final List<Duration> durations = resolver.resolve(selection);
+
+        // then
+        assertThat(durations).isEqualTo(expectedDurations);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 커스텀 주기를 resolve하면 예외를 던진다")
+    void resolve_notFound() {
+        // given
+        final Long cycleOptionId = 999L;
+        final CustomCycleSelection selection = new CustomCycleSelection(cycleOptionId);
+
+        given(cycleOptionRepository.findById(cycleOptionId)).willReturn(Optional.empty());
+
+        // when
+        // then
+        assertThatThrownBy(() -> resolver.resolve(selection))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("존재하지 않는 주기 옵션입니다.");
+    }
+}

--- a/src/test/java/com/recyclestudy/cycle/service/resolver/CycleSelectionResolverRegistryTest.java
+++ b/src/test/java/com/recyclestudy/cycle/service/resolver/CycleSelectionResolverRegistryTest.java
@@ -1,0 +1,63 @@
+package com.recyclestudy.cycle.service.resolver;
+
+import com.recyclestudy.cycle.domain.DefaultCycleOption;
+import com.recyclestudy.cycle.domain.selection.CustomCycleSelection;
+import com.recyclestudy.cycle.domain.selection.CycleSelection;
+import com.recyclestudy.cycle.domain.selection.DefaultCycleSelection;
+import com.recyclestudy.cycle.repository.CycleOptionRepository;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ExtendWith(MockitoExtension.class)
+class CycleSelectionResolverRegistryTest {
+
+    @Mock
+    CycleOptionRepository cycleOptionRepository;
+
+    CycleSelectionResolverRegistry registry;
+
+    @BeforeEach
+    void setUp() {
+        final List<CycleSelectionResolver<?>> resolvers = List.of(
+                new DefaultCycleSelectionResolver(),
+                new CustomCycleSelectionResolver(cycleOptionRepository)
+        );
+        registry = new CycleSelectionResolverRegistry(resolvers);
+    }
+
+    @Test
+    @DisplayName("DefaultCycleSelection을 resolve할 수 있다")
+    void resolve_default() {
+        // given
+        final CycleSelection selection = new DefaultCycleSelection("EBBINGHAUS");
+
+        // when
+        final List<Duration> durations = registry.resolve(selection);
+
+        // then
+        assertThat(durations).isEqualTo(DefaultCycleOption.EBBINGHAUS.getDurations());
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 타입을 resolve하면 예외를 던진다")
+    void resolve_unsupportedType() {
+        // given
+        final CycleSelectionResolverRegistry emptyRegistry = new CycleSelectionResolverRegistry(List.of());
+        final CycleSelection selection = new DefaultCycleSelection("EBBINGHAUS");
+
+        // when
+        // then
+        assertThatThrownBy(() -> emptyRegistry.resolve(selection))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("지원하지 않는 주기 타입입니다");
+    }
+}

--- a/src/test/java/com/recyclestudy/cycle/service/resolver/DefaultCycleSelectionResolverTest.java
+++ b/src/test/java/com/recyclestudy/cycle/service/resolver/DefaultCycleSelectionResolverTest.java
@@ -1,0 +1,38 @@
+package com.recyclestudy.cycle.service.resolver;
+
+import com.recyclestudy.cycle.domain.DefaultCycleOption;
+import com.recyclestudy.cycle.domain.selection.DefaultCycleSelection;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DefaultCycleSelectionResolverTest {
+
+    private final DefaultCycleSelectionResolver resolver = new DefaultCycleSelectionResolver();
+
+    @Test
+    @DisplayName("지원하는 타입은 DefaultCycleSelection이다")
+    void getSupportedType() {
+        // when
+        final Class<DefaultCycleSelection> supportedType = resolver.getSupportedType();
+
+        // then
+        assertThat(supportedType).isEqualTo(DefaultCycleSelection.class);
+    }
+
+    @Test
+    @DisplayName("기본 주기 선택을 resolve하면 해당 주기의 durations를 반환한다")
+    void resolve() {
+        // given
+        final DefaultCycleSelection selection = new DefaultCycleSelection("EBBINGHAUS");
+
+        // when
+        final List<Duration> durations = resolver.resolve(selection);
+
+        // then
+        assertThat(durations).isEqualTo(DefaultCycleOption.EBBINGHAUS.getDurations());
+    }
+}

--- a/src/test/java/com/recyclestudy/cycle/util/CycleDurationParserTest.java
+++ b/src/test/java/com/recyclestudy/cycle/util/CycleDurationParserTest.java
@@ -1,0 +1,43 @@
+package com.recyclestudy.cycle.util;
+
+import com.recyclestudy.exception.BadRequestException;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CycleDurationParserTest {
+
+    @Test
+    @DisplayName("문자열 포맷 리스트를 Duration 리스트로 변환한다")
+    void parseList() {
+        // given
+        final List<String> formats = List.of("PT10M", "PT1H", "P1D");
+
+        // when
+        final List<Duration> actual = CycleDurationParser.parseList(formats);
+
+        // then
+        assertThat(actual).containsExactly(
+                Duration.ofMinutes(10),
+                Duration.ofHours(1),
+                Duration.ofDays(1)
+        );
+    }
+
+    @Test
+    @DisplayName("잘못된 형식의 문자열이 포함되면 BadRequestException이 발생한다")
+    void parseList_invalidFormat_throwsException() {
+        // given
+        final List<String> formats = List.of("PT10M", "10분");
+
+        // when
+        // then
+        assertThatThrownBy(() -> CycleDurationParser.parseList(formats))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("잘못된 주기 형식입니다");
+    }
+}

--- a/src/test/java/com/recyclestudy/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/recyclestudy/member/controller/MemberControllerTest.java
@@ -439,7 +439,8 @@ class MemberControllerTest extends APIBaseTest {
                                 )
                                 .queryParameters(
                                         parameterWithName("email").description("이메일"),
-                                        parameterWithName("identifier").description("디바이스 식별자 (deprecated, 헤더 사용 권장)").optional()
+                                        parameterWithName("identifier").description("디바이스 식별자 (deprecated, 헤더 사용 권장)")
+                                                .optional()
                                 )
                                 .responseFields(
                                         fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),

--- a/src/test/java/com/recyclestudy/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/recyclestudy/review/controller/ReviewControllerTest.java
@@ -53,6 +53,50 @@ class ReviewControllerTest extends APIBaseTest {
     }
 
     @Test
+    @DisplayName("cycle 없이 리뷰를 저장하면 기본 주기로 201 응답을 반환한다 (하위 호환)")
+    void saveReview_withoutCycle_backwardCompatible() {
+        // given
+        final String identifier = "device-id";
+        final String url = "https://test.com";
+        final ReviewSaveRequest request = new ReviewSaveRequest(url, null);
+        final ReviewSaveOutput output = ReviewSaveOutput.of(ReviewURL.from(url), List.of(LocalDateTime.now()));
+
+        given(reviewService.saveReview(any())).willReturn(output);
+
+        // when
+        // then
+        given(this.spec)
+                .filter(document(DEFAULT_REST_DOC_PATH,
+                        builder()
+                                .tag("Review")
+                                .summary("리뷰 저장 (하위 호환)")
+                                .description("cycle 없이 리뷰를 저장하면 기본 주기(EBBINGHAUS)로 저장된다")
+                                .requestHeaders(
+                                        headerWithName("X-Device-Id").description("디바이스 식별자")
+                                )
+                                .requestFields(
+                                        fieldWithPath("targetUrl").type(JsonFieldType.STRING)
+                                                .description("리뷰할 URL"),
+                                        fieldWithPath("cycle").type(JsonFieldType.NULL)
+                                                .description("복습 주기 선택 (null이면 기본 주기 사용)").optional()
+                                )
+                                .responseFields(
+                                        fieldWithPath("url").type(JsonFieldType.STRING).description("리뷰할 URL"),
+                                        fieldWithPath("scheduledAts").type(JsonFieldType.ARRAY)
+                                                .description("복습 예정 일시 목록")
+                                )
+                ))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("X-Device-Id", identifier)
+                .body(request)
+                .when()
+                .post("/api/v1/reviews")
+                .then()
+                .statusCode(HttpStatus.CREATED.value())
+                .body("url", equalTo(url));
+    }
+
+    @Test
     @DisplayName("기본 주기로 리뷰를 저장하면 201 응답을 반환한다")
     void saveReview_withDefaultCycle() {
         // given

--- a/src/test/java/com/recyclestudy/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/recyclestudy/review/controller/ReviewControllerTest.java
@@ -1,5 +1,6 @@
 package com.recyclestudy.review.controller;
 
+import com.recyclestudy.cycle.domain.selection.DefaultCycleSelection;
 import com.recyclestudy.exception.UnauthorizedException;
 import com.recyclestudy.member.domain.ActivationExpiredDateTime;
 import com.recyclestudy.member.domain.Device;
@@ -52,12 +53,13 @@ class ReviewControllerTest extends APIBaseTest {
     }
 
     @Test
-    @DisplayName("리뷰를 저장하면 201 응답을 반환한다")
-    void saveReview() {
+    @DisplayName("기본 주기로 리뷰를 저장하면 201 응답을 반환한다")
+    void saveReview_withDefaultCycle() {
         // given
         final String identifier = "device-id";
         final String url = "https://test.com";
-        final ReviewSaveRequest request = new ReviewSaveRequest(url);
+        final DefaultCycleSelection cycleSelection = new DefaultCycleSelection("EBBINGHAUS");
+        final ReviewSaveRequest request = new ReviewSaveRequest(url, cycleSelection);
         final ReviewSaveOutput output = ReviewSaveOutput.of(ReviewURL.from(url), List.of(LocalDateTime.now()));
 
         given(reviewService.saveReview(any())).willReturn(output);
@@ -69,13 +71,19 @@ class ReviewControllerTest extends APIBaseTest {
                         builder()
                                 .tag("Review")
                                 .summary("리뷰 저장")
-                                .description("리뷰를 저장하면 201 응답을 반환한다")
+                                .description("기본 주기로 리뷰를 저장하면 201 응답을 반환한다")
                                 .requestHeaders(
                                         headerWithName("X-Device-Id").description("디바이스 식별자")
                                 )
                                 .requestFields(
                                         fieldWithPath("targetUrl").type(JsonFieldType.STRING)
-                                                .description("리뷰할 URL")
+                                                .description("리뷰할 URL"),
+                                        fieldWithPath("cycle").type(JsonFieldType.OBJECT)
+                                                .description("복습 주기 선택"),
+                                        fieldWithPath("cycle.type").type(JsonFieldType.STRING)
+                                                .description("주기 타입 (DEFAULT 또는 CUSTOM)"),
+                                        fieldWithPath("cycle.code").type(JsonFieldType.STRING)
+                                                .description("기본 주기 코드 (DEFAULT 타입일 때)")
                                 )
                                 .responseFields(
                                         fieldWithPath("url").type(JsonFieldType.STRING).description("리뷰할 URL"),
@@ -98,7 +106,8 @@ class ReviewControllerTest extends APIBaseTest {
     void saveReview_Unauthorized() {
         // given
         final String identifier = "invalid-id";
-        final ReviewSaveRequest request = new ReviewSaveRequest("https://test.com");
+        final DefaultCycleSelection cycleSelection = new DefaultCycleSelection("EBBINGHAUS");
+        final ReviewSaveRequest request = new ReviewSaveRequest("https://test.com", cycleSelection);
 
         given(reviewService.saveReview(any()))
                 .willThrow(new UnauthorizedException("유효하지 않은 디바이스입니다"));
@@ -116,7 +125,13 @@ class ReviewControllerTest extends APIBaseTest {
                                 )
                                 .requestFields(
                                         fieldWithPath("targetUrl").type(JsonFieldType.STRING)
-                                                .description("리뷰할 URL")
+                                                .description("리뷰할 URL"),
+                                        fieldWithPath("cycle").type(JsonFieldType.OBJECT)
+                                                .description("복습 주기 선택"),
+                                        fieldWithPath("cycle.type").type(JsonFieldType.STRING)
+                                                .description("주기 타입"),
+                                        fieldWithPath("cycle.code").type(JsonFieldType.STRING)
+                                                .description("기본 주기 코드")
                                 )
                                 .responseFields(
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("에러 메시지")
@@ -137,7 +152,8 @@ class ReviewControllerTest extends APIBaseTest {
     void saveReview_InactiveDevice() {
         // given
         final String identifier = "inactive-id";
-        final ReviewSaveRequest request = new ReviewSaveRequest("https://test.com");
+        final DefaultCycleSelection cycleSelection = new DefaultCycleSelection("EBBINGHAUS");
+        final ReviewSaveRequest request = new ReviewSaveRequest("https://test.com", cycleSelection);
 
         given(reviewService.saveReview(any()))
                 .willThrow(new UnauthorizedException("인증되지 않은 디바이스입니다"));
@@ -155,7 +171,13 @@ class ReviewControllerTest extends APIBaseTest {
                                 )
                                 .requestFields(
                                         fieldWithPath("targetUrl").type(JsonFieldType.STRING)
-                                                .description("리뷰할 URL")
+                                                .description("리뷰할 URL"),
+                                        fieldWithPath("cycle").type(JsonFieldType.OBJECT)
+                                                .description("복습 주기 선택"),
+                                        fieldWithPath("cycle.type").type(JsonFieldType.STRING)
+                                                .description("주기 타입"),
+                                        fieldWithPath("cycle.code").type(JsonFieldType.STRING)
+                                                .description("기본 주기 코드")
                                 )
                                 .responseFields(
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("에러 메시지")

--- a/src/test/java/com/recyclestudy/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/recyclestudy/review/service/ReviewServiceTest.java
@@ -1,5 +1,7 @@
 package com.recyclestudy.review.service;
 
+import com.recyclestudy.cycle.domain.selection.DefaultCycleSelection;
+import com.recyclestudy.cycle.service.resolver.CycleSelectionResolverRegistry;
 import com.recyclestudy.exception.UnauthorizedException;
 import com.recyclestudy.member.domain.DeviceIdentifier;
 import com.recyclestudy.member.domain.Email;
@@ -16,6 +18,7 @@ import com.recyclestudy.review.repository.ReviewRepository;
 import com.recyclestudy.review.service.input.ReviewSaveInput;
 import com.recyclestudy.review.service.output.ReviewSaveOutput;
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -51,6 +54,9 @@ class ReviewServiceTest {
     MemberRepository memberRepository;
 
     @Mock
+    CycleSelectionResolverRegistry cycleSelectionResolverRegistry;
+
+    @Mock
     NotificationHistoryRepository notificationHistoryRepository;
 
     @Spy
@@ -72,14 +78,18 @@ class ReviewServiceTest {
         // given
         final DeviceIdentifier identifier = DeviceIdentifier.from("device-id");
         final String urlValue = "https://test.com";
-        final ReviewSaveInput input = ReviewSaveInput.of(identifier, urlValue);
+        final DefaultCycleSelection cycleSelection = new DefaultCycleSelection("EBBINGHAUS");
+        final ReviewSaveInput input = ReviewSaveInput.of(identifier, urlValue, cycleSelection);
 
         final Email email = Email.from("test@test.com");
         final Member member = Member.withoutId(email);
         final Review review = Review.withoutId(member, ReviewURL.from(urlValue));
         final ReviewCycle cycle = ReviewCycle.withoutId(review, now.plusDays(1));
 
+        final List<Duration> durations = List.of(Duration.ofDays(1));
+
         given(memberRepository.findByIdentifier(any(DeviceIdentifier.class))).willReturn(Optional.of(member));
+        given(cycleSelectionResolverRegistry.resolve(cycleSelection)).willReturn(durations);
         given(reviewRepository.save(any(Review.class))).willReturn(review);
         given(reviewCycleRepository.saveAll(anyList())).willReturn(List.of(cycle));
 
@@ -97,6 +107,7 @@ class ReviewServiceTest {
         });
 
         verify(memberRepository).findByIdentifier(any(DeviceIdentifier.class));
+        verify(cycleSelectionResolverRegistry).resolve(cycleSelection);
         verify(reviewRepository).save(any(Review.class));
         verify(reviewCycleRepository).saveAll(anyList());
     }
@@ -105,7 +116,12 @@ class ReviewServiceTest {
     @DisplayName("존재하지 않는 디바이스 아이디일 경우 예외를 던진다")
     void saveReview_fail_notFoundDevice() {
         // given
-        final ReviewSaveInput input = ReviewSaveInput.of(DeviceIdentifier.from("not-found"), "https://test.com");
+        final DefaultCycleSelection cycleSelection = new DefaultCycleSelection("EBBINGHAUS");
+        final ReviewSaveInput input = ReviewSaveInput.of(
+                DeviceIdentifier.from("not-found"),
+                "https://test.com",
+                cycleSelection
+        );
         given(memberRepository.findByIdentifier(any(DeviceIdentifier.class))).willReturn(Optional.empty());
 
         // when

--- a/src/test/java/com/recyclestudy/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/recyclestudy/review/service/ReviewServiceTest.java
@@ -113,6 +113,39 @@ class ReviewServiceTest {
     }
 
     @Test
+    @DisplayName("cycle이 null이면 기본 주기(EBBINGHAUS)를 사용한다")
+    void saveReview_withNullCycle_usesDefaultCycle() {
+        // given
+        final DeviceIdentifier identifier = DeviceIdentifier.from("device-id");
+        final String urlValue = "https://test.com";
+        final ReviewSaveInput input = ReviewSaveInput.of(identifier, urlValue, null);
+
+        final Email email = Email.from("test@test.com");
+        final Member member = Member.withoutId(email);
+        final Review review = Review.withoutId(member, ReviewURL.from(urlValue));
+        final ReviewCycle cycle = ReviewCycle.withoutId(review, now.plusDays(1));
+
+        final List<Duration> durations = List.of(Duration.ofDays(1));
+        final DefaultCycleSelection defaultCycle = new DefaultCycleSelection("EBBINGHAUS");
+
+        given(memberRepository.findByIdentifier(any(DeviceIdentifier.class))).willReturn(Optional.of(member));
+        given(cycleSelectionResolverRegistry.resolve(defaultCycle)).willReturn(durations);
+        given(reviewRepository.save(any(Review.class))).willReturn(review);
+        given(reviewCycleRepository.saveAll(anyList())).willReturn(List.of(cycle));
+
+        // when
+        final ReviewSaveOutput actual = reviewService.saveReview(input);
+
+        // then
+        assertSoftly(softAssertions -> {
+            softAssertions.assertThat(actual.url()).isEqualTo(ReviewURL.from(urlValue));
+            softAssertions.assertThat(actual.scheduledAts()).hasSize(1);
+        });
+
+        verify(cycleSelectionResolverRegistry).resolve(defaultCycle);
+    }
+
+    @Test
     @DisplayName("존재하지 않는 디바이스 아이디일 경우 예외를 던진다")
     void saveReview_fail_notFoundDevice() {
         // given


### PR DESCRIPTION
<!-- PR 템플릿 -->

## 🚀 작업 내용

사용자 커스텀 복습 주기 관리 및 커스텀 주기 기반 리뷰 저장 기능 구현

### 주기 선택 전략 패턴 도입 (`CycleSelection` & `Resolver`)
- 리뷰 생성 시 선택된 주기가 '기본 주기'인지 '커스텀 주기'인지에 따라 처리하는 로직을 전략 패턴으로 구현
- `CycleSelection`: 선택된 주기의 정보를 담는 추상 레이어를 도입
- `CycleSelectionResolver`: 입력된 주기 정보(코드 또는 ID)를 바탕으로 실제 주기를 찾아오는 책임 분리
  - `DefaultCycleSelectionResolver`: 시스템 기본 주기를 매핑
  - `CustomCycleSelectionResolver`: 사용자가 정의한 커스텀 주기를 매핑
- `CycleSelectionResolverRegistry`: 다양한 리졸버 중 적절한 전략을 선택하는 중앙 관리 객체를 도입

### `ReviewService` 비즈니스 로직 고도화
- 리뷰 저장 시 입력받은 주기 식별자를 바탕으로 `CycleSelection`을 추출하고, 이에 따라 복습 주기를 자동으로 계산하여 저장하는 로직 구현

### 커스텀 주기 옵션 관리 기능
- 사용자가 커스텀 복습 주기를 구성할 수 있는 CRUD 기능 구현
- `CycleDurations` 일급 컬렉션을 통해 주기 데이터의 유효성(최소 1개, 10분 단위, 1년 이내 등)을 도메인 레벨에서 강제

### 입력값 파싱 및 검증 리팩토링
- `CycleDurationParser`를 도입하여 `ISO-8601` 포맷 파싱 로직을 유틸리티화
- 파싱 책임을 Controller Request DTO로 이동시켜 Service 계층이 타입 안정성이 보장된 데이터만 다루도록 개선

## 📸 이슈 번호

- close #52 

## ✍ 궁금한 점

- 리뷰 생성 시 주기를 확정 짓는 로직이 `ReviewService`에 위치해 있는데, 이를 도메인 서비스 등으로 더 분리할 필요가 있을까?
