### PR TITLE
이메일 전송 실패 재시도 로직 구현

### DIFF
--- a/src/main/java/com/recyclestudy/email/EmailRetryScheduler.java
+++ b/src/main/java/com/recyclestudy/email/EmailRetryScheduler.java
@@ -1,0 +1,17 @@
+package com.recyclestudy.email;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EmailRetryScheduler {
+
+    private final EmailRetryService emailRetryService;
+
+    @Scheduled(fixedDelay = 60_000)
+    public void runRetry() {
+        emailRetryService.retryFailedEmails();
+    }
+}

--- a/src/main/java/com/recyclestudy/email/EmailRetryService.java
+++ b/src/main/java/com/recyclestudy/email/EmailRetryService.java
@@ -1,0 +1,64 @@
+package com.recyclestudy.email;
+
+import com.recyclestudy.member.domain.Member;
+import com.recyclestudy.review.domain.NotificationStatus;
+import com.recyclestudy.review.domain.ReviewCycle;
+import com.recyclestudy.review.domain.ReviewURL;
+import com.recyclestudy.review.repository.ReviewCycleRepository;
+import com.recyclestudy.review.service.output.ReviewSendOutput.ReviewSendElement;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailRetryService {
+
+    private static final int MAX_RETRY_COUNT = 3;
+
+    private final ReviewCycleRepository reviewCycleRepository;
+    private final SingleReviewEmailSender singleReviewEmailSender;
+
+    @Transactional(readOnly = true)
+    public void retryFailedEmails() {
+        final List<ReviewCycle> failedCycles = reviewCycleRepository.findAllRetryableCycles(
+                MAX_RETRY_COUNT,
+                NotificationStatus.SENT
+        );
+
+        if (failedCycles.isEmpty()) {
+            return;
+        }
+
+        log.info("[EMAIL_RETRY] 재시도 대상 {}건 발견", failedCycles.size());
+
+        final Map<Member, List<ReviewCycle>> cyclesByMember = failedCycles.stream()
+                .collect(Collectors.groupingBy(reviewCycle -> reviewCycle.getReview().getMember()));
+
+        for (final Map.Entry<Member, List<ReviewCycle>> entry : cyclesByMember.entrySet()) {
+            final Member member = entry.getKey();
+            final List<ReviewCycle> cycles = entry.getValue();
+
+            final List<ReviewURL> urls = cycles.stream()
+                    .map(rc -> rc.getReview().getUrl())
+                    .toList();
+
+            final List<Long> cycleIds = cycles.stream()
+                    .map(ReviewCycle::getId)
+                    .toList();
+
+            final ReviewSendElement element = ReviewSendElement.of(
+                    member.getEmail(),
+                    cycleIds,
+                    urls
+            );
+
+            singleReviewEmailSender.sendOne(element);
+        }
+    }
+}

--- a/src/main/java/com/recyclestudy/email/EmailRetryService.java
+++ b/src/main/java/com/recyclestudy/email/EmailRetryService.java
@@ -1,7 +1,6 @@
 package com.recyclestudy.email;
 
 import com.recyclestudy.member.domain.Member;
-import com.recyclestudy.review.domain.NotificationStatus;
 import com.recyclestudy.review.domain.ReviewCycle;
 import com.recyclestudy.review.domain.ReviewURL;
 import com.recyclestudy.review.repository.ReviewCycleRepository;
@@ -26,10 +25,7 @@ public class EmailRetryService {
 
     @Transactional(readOnly = true)
     public void retryFailedEmails() {
-        final List<ReviewCycle> failedCycles = reviewCycleRepository.findAllRetryableCycles(
-                MAX_RETRY_COUNT,
-                NotificationStatus.SENT
-        );
+        final List<ReviewCycle> failedCycles = reviewCycleRepository.findAllRetryableCycles(MAX_RETRY_COUNT);
 
         if (failedCycles.isEmpty()) {
             return;
@@ -43,22 +39,25 @@ public class EmailRetryService {
         for (final Map.Entry<Member, List<ReviewCycle>> entry : cyclesByMember.entrySet()) {
             final Member member = entry.getKey();
             final List<ReviewCycle> cycles = entry.getValue();
-
-            final List<ReviewURL> urls = cycles.stream()
-                    .map(rc -> rc.getReview().getUrl())
-                    .toList();
-
-            final List<Long> cycleIds = cycles.stream()
-                    .map(ReviewCycle::getId)
-                    .toList();
-
-            final ReviewSendElement element = ReviewSendElement.of(
-                    member.getEmail(),
-                    cycleIds,
-                    urls
-            );
-
-            singleReviewEmailSender.sendOne(element);
+            sendOneRetryEmail(cycles, member);
         }
+    }
+
+    private void sendOneRetryEmail(final List<ReviewCycle> cycles, final Member member) {
+        final List<ReviewURL> urls = cycles.stream()
+                .map(reviewCycle -> reviewCycle.getReview().getUrl())
+                .toList();
+
+        final List<Long> cycleIds = cycles.stream()
+                .map(ReviewCycle::getId)
+                .toList();
+
+        final ReviewSendElement element = ReviewSendElement.of(
+                member.getEmail(),
+                cycleIds,
+                urls
+        );
+
+        singleReviewEmailSender.sendOne(element);
     }
 }

--- a/src/main/java/com/recyclestudy/email/EmailSender.java
+++ b/src/main/java/com/recyclestudy/email/EmailSender.java
@@ -27,9 +27,7 @@ public class EmailSender {
             helper.setText(content, true);
 
             javaMailSender.send(mimeMessage);
-
             log.info("[MAIL_SENT] 메일 발송 성공: email={}", targetEmail.toMaskedValue());
-
         } catch (MessagingException e) {
             log.error("[MAIL_SEND_FAILED] 메일 발송 실패: email={}", targetEmail, e);
             throw new EmailSendException("메일 전송 중 오류가 발생했습니다.", e);

--- a/src/main/java/com/recyclestudy/email/EmailSender.java
+++ b/src/main/java/com/recyclestudy/email/EmailSender.java
@@ -29,7 +29,7 @@ public class EmailSender {
             javaMailSender.send(mimeMessage);
             log.info("[MAIL_SENT] 메일 발송 성공: email={}", targetEmail.toMaskedValue());
         } catch (MessagingException e) {
-            log.error("[MAIL_SEND_FAILED] 메일 발송 실패: email={}", targetEmail, e);
+            log.error("[MAIL_SEND_FAILED] 메일 발송 실패: email={}", targetEmail.toMaskedValue(), e);
             throw new EmailSendException("메일 전송 중 오류가 발생했습니다.", e);
         }
     }

--- a/src/main/java/com/recyclestudy/email/ReviewEmailSender.java
+++ b/src/main/java/com/recyclestudy/email/ReviewEmailSender.java
@@ -5,9 +5,7 @@ import com.recyclestudy.review.service.input.ReviewSendInput;
 import com.recyclestudy.review.service.output.ReviewSendOutput;
 import com.recyclestudy.review.service.output.ReviewSendOutput.ReviewSendElement;
 import java.time.Clock;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -26,17 +24,13 @@ public class ReviewEmailSender {
 
     @Scheduled(cron = "${schedule.review-mail.cron}", zone = "Asia/Seoul")
     public void sendReviewMail() {
-
-        final LocalDate targetDate = LocalDate.now(clock);
-        final LocalTime targetTime = LocalTime.of(8, 0);
-
         final LocalDateTime targetDateTime = LocalDateTime.now(clock).truncatedTo(ChronoUnit.MINUTES);
 
         final ReviewSendOutput targetReviewCycle = reviewCycleService.findTargetReviewCycle(
                 ReviewSendInput.from(targetDateTime));
 
         final List<ReviewSendElement> elements = targetReviewCycle.elements();
-        log.info("[REVIEW_MAIL_SENT] 복습 메일 발송 시작: date={}, time={}, size={}", targetDate, targetTime, elements.size());
+        log.info("[REVIEW_MAIL_SENT] 복습 메일 발송 시작: datetime={}, size={}", targetDateTime, elements.size());
 
         for (final ReviewSendElement element : elements) {
             singleReviewEmailSender.sendOne(element);

--- a/src/main/java/com/recyclestudy/email/ReviewEmailSender.java
+++ b/src/main/java/com/recyclestudy/email/ReviewEmailSender.java
@@ -1,9 +1,5 @@
 package com.recyclestudy.email;
 
-import com.recyclestudy.member.domain.Email;
-import com.recyclestudy.review.domain.NotificationStatus;
-import com.recyclestudy.review.domain.ReviewURL;
-import com.recyclestudy.review.service.NotificationHistoryService;
 import com.recyclestudy.review.service.ReviewCycleService;
 import com.recyclestudy.review.service.input.ReviewSendInput;
 import com.recyclestudy.review.service.output.ReviewSendOutput;
@@ -16,21 +12,17 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-import org.thymeleaf.TemplateEngine;
-import org.thymeleaf.context.Context;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class ReviewEmailSender {
 
-    private final EmailSender emailSender;
-    private final TemplateEngine templateEngine;
+    private final SingleReviewEmailSender singleReviewEmailSender;
     private final ReviewCycleService reviewCycleService;
-    private final NotificationHistoryService notificationHistoryService;
     private final Clock clock;
 
-    @Scheduled(cron = "0 0 8 * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "${schedule.review-mail.cron}", zone = "Asia/Seoul")
     public void sendReviewMail() {
 
         final LocalDate targetDate = LocalDate.now(clock);
@@ -42,40 +34,10 @@ public class ReviewEmailSender {
         final List<ReviewSendElement> elements = targetReviewCycle.elements();
         log.info("[REVIEW_MAIL_SENT] 복습 메일 발송 시작: date={}, time={}, size={}", targetDate, targetTime, elements.size());
 
-        int successCount = 0;
-        int failCount = 0;
-
         for (final ReviewSendElement element : elements) {
-            final String message = createMessage(element.targetUrls());
-            final Email targetEmail = element.email();
-
-            final boolean success = sendToTargetEmail(targetEmail, message);
-
-            if (success) {
-                notificationHistoryService.saveAll(element.reviewCycleIds(), NotificationStatus.SENT);
-                successCount++;
-            } else {
-                notificationHistoryService.saveAll(element.reviewCycleIds(), NotificationStatus.FAILED);
-                failCount++;
-            }
+            singleReviewEmailSender.sendOne(element);
         }
 
-        log.info("[REVIEW_MAIL_SENT] 복습 메일 발송 처리 완료: success={}, fail={}", successCount, failCount);
-    }
-
-    private boolean sendToTargetEmail(final Email targetEmail, final String message) {
-        try {
-            emailSender.send(targetEmail, "[Recycle Study] 오늘의 복습 목록이 도착했습니다", message);
-            return true;
-        } catch (final Exception e) {
-            log.error("[REVIEW_MAIL_SEND_FAILED] 복습 메일 발송 실패: email={}", targetEmail.getValue(), e);
-            return false;
-        }
-    }
-
-    private String createMessage(final List<ReviewURL> targetUrls) {
-        final Context context = new Context();
-        context.setVariable("targetUrls", targetUrls);
-        return templateEngine.process("review_email", context);
+        log.info("[REVIEW_MAIL_SENT] 복습 메일 발송 요청 완료: size={}", elements.size());
     }
 }

--- a/src/main/java/com/recyclestudy/email/ReviewEmailSender.java
+++ b/src/main/java/com/recyclestudy/email/ReviewEmailSender.java
@@ -6,16 +6,18 @@ import com.recyclestudy.review.service.output.ReviewSendOutput;
 import com.recyclestudy.review.service.output.ReviewSendOutput.ReviewSendElement;
 import java.time.Clock;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class ReviewEmailSender {
 
     private final SingleReviewEmailSender singleReviewEmailSender;
@@ -28,8 +30,10 @@ public class ReviewEmailSender {
         final LocalDate targetDate = LocalDate.now(clock);
         final LocalTime targetTime = LocalTime.of(8, 0);
 
+        final LocalDateTime targetDateTime = LocalDateTime.now(clock).truncatedTo(ChronoUnit.MINUTES);
+
         final ReviewSendOutput targetReviewCycle = reviewCycleService.findTargetReviewCycle(
-                ReviewSendInput.from(targetDate, targetTime));
+                ReviewSendInput.from(targetDateTime));
 
         final List<ReviewSendElement> elements = targetReviewCycle.elements();
         log.info("[REVIEW_MAIL_SENT] 복습 메일 발송 시작: date={}, time={}, size={}", targetDate, targetTime, elements.size());

--- a/src/main/java/com/recyclestudy/email/SingleReviewEmailSender.java
+++ b/src/main/java/com/recyclestudy/email/SingleReviewEmailSender.java
@@ -1,0 +1,54 @@
+package com.recyclestudy.email;
+
+import com.recyclestudy.member.domain.Email;
+import com.recyclestudy.review.domain.NotificationStatus;
+import com.recyclestudy.review.domain.ReviewURL;
+import com.recyclestudy.review.service.NotificationHistoryService;
+import com.recyclestudy.review.service.output.ReviewSendOutput.ReviewSendElement;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SingleReviewEmailSender {
+
+    private final EmailSender emailSender;
+    private final TemplateEngine templateEngine;
+    private final NotificationHistoryService notificationHistoryService;
+
+    @Async
+    public void sendOne(final ReviewSendElement element) {
+        final String message = createMessage(element.targetUrls());
+        final Email targetEmail = element.email();
+
+        final boolean success = sendToTargetEmail(targetEmail, message);
+
+        if (success) {
+            notificationHistoryService.saveAll(element.reviewCycleIds(), NotificationStatus.SENT);
+            return;
+        }
+        notificationHistoryService.saveAll(element.reviewCycleIds(), NotificationStatus.FAILED);
+    }
+
+    private boolean sendToTargetEmail(final Email targetEmail, final String message) {
+        try {
+            emailSender.send(targetEmail, "[Recycle Study] 오늘의 복습 목록이 도착했습니다", message);
+            return true;
+        } catch (final Exception e) {
+            log.error("[REVIEW_MAIL_SEND_FAILED] 복습 메일 발송 실패: email={}", targetEmail.getValue(), e);
+            return false;
+        }
+    }
+
+    private String createMessage(final List<ReviewURL> targetUrls) {
+        final Context context = new Context();
+        context.setVariable("targetUrls", targetUrls);
+        return templateEngine.process("review_email", context);
+    }
+}

--- a/src/main/java/com/recyclestudy/review/repository/ReviewCycleRepository.java
+++ b/src/main/java/com/recyclestudy/review/repository/ReviewCycleRepository.java
@@ -1,11 +1,26 @@
 package com.recyclestudy.review.repository;
 
+import com.recyclestudy.review.domain.NotificationStatus;
 import com.recyclestudy.review.domain.ReviewCycle;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ReviewCycleRepository extends JpaRepository<ReviewCycle, Long> {
 
     List<ReviewCycle> findAllByScheduledAt(LocalDateTime scheduledAt);
+
+    @Query("""
+            SELECT rc FROM ReviewCycle rc
+            JOIN NotificationHistory nh ON rc.id = nh.reviewCycle.id
+            GROUP BY rc
+            HAVING SUM(CASE WHEN nh.status = :sentStatus THEN 1 ELSE 0 END) = 0
+            AND COUNT(nh) < :maxRetryCount
+            """)
+    List<ReviewCycle> findAllRetryableCycles(
+            @Param("maxRetryCount") long maxRetryCount,
+            @Param("sentStatus") NotificationStatus sentStatus
+    );
 }

--- a/src/main/java/com/recyclestudy/review/repository/ReviewCycleRepository.java
+++ b/src/main/java/com/recyclestudy/review/repository/ReviewCycleRepository.java
@@ -16,11 +16,9 @@ public interface ReviewCycleRepository extends JpaRepository<ReviewCycle, Long> 
             SELECT rc FROM ReviewCycle rc
             JOIN NotificationHistory nh ON rc.id = nh.reviewCycle.id
             GROUP BY rc
-            HAVING SUM(CASE WHEN nh.status = :sentStatus THEN 1 ELSE 0 END) = 0
-            AND COUNT(nh) < :maxRetryCount
+            HAVING SUM(CASE WHEN nh.status = 'SENT' THEN 1 ELSE 0 END) = 0
+            AND SUM(CASE WHEN nh.status = 'FAILED' THEN 1 ELSE 0 END) > 0
+            AND SUM(CASE WHEN nh.status = 'FAILED' THEN 1 ELSE 0 END) < :maxRetryCount
             """)
-    List<ReviewCycle> findAllRetryableCycles(
-            @Param("maxRetryCount") long maxRetryCount,
-            @Param("sentStatus") NotificationStatus sentStatus
-    );
+    List<ReviewCycle> findAllRetryableCycles(@Param("maxRetryCount") long maxRetryCount);
 }

--- a/src/main/java/com/recyclestudy/review/service/input/ReviewSendInput.java
+++ b/src/main/java/com/recyclestudy/review/service/input/ReviewSendInput.java
@@ -1,12 +1,10 @@
 package com.recyclestudy.review.service.input;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 
 public record ReviewSendInput(LocalDateTime scheduledAt) {
 
-    public static ReviewSendInput from(final LocalDate targetDate, final LocalTime targetTime) {
-        return new ReviewSendInput(LocalDateTime.of(targetDate, targetTime));
+    public static ReviewSendInput from(final LocalDateTime targetDateTime) {
+        return new ReviewSendInput(targetDateTime);
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -66,3 +66,7 @@ management:
 
 auth:
   base-url: ${BASE_URL}
+
+schedule:
+  review-mail:
+    cron: "0 0 8 * * *"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -69,4 +69,4 @@ auth:
 
 schedule:
   review-mail:
-    cron: "0 0 8 * * *"
+    cron: "0 * * * * *"

--- a/src/test/java/com/recyclestudy/email/EmailRetryServiceTest.java
+++ b/src/test/java/com/recyclestudy/email/EmailRetryServiceTest.java
@@ -1,0 +1,84 @@
+package com.recyclestudy.email;
+
+import com.recyclestudy.member.domain.Email;
+import com.recyclestudy.member.domain.Member;
+import com.recyclestudy.review.domain.Review;
+import com.recyclestudy.review.domain.ReviewCycle;
+import com.recyclestudy.review.domain.ReviewURL;
+import com.recyclestudy.review.repository.ReviewCycleRepository;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class EmailRetryServiceTest {
+
+    @Mock
+    ReviewCycleRepository reviewCycleRepository;
+
+    @Mock
+    SingleReviewEmailSender singleReviewEmailSender;
+
+    @InjectMocks
+    EmailRetryService emailRetryService;
+
+    @Test
+    @DisplayName("재시도 대상이 없으면 아무 동작도 하지 않는다")
+    void retryFailedEmails_noData() {
+        // given
+        given(reviewCycleRepository.findAllRetryableCycles(any(Long.class), any())).willReturn(Collections.emptyList());
+
+        // when
+        emailRetryService.retryFailedEmails();
+
+        // then
+        verify(singleReviewEmailSender, never()).sendOne(any());
+    }
+
+    @Test
+    @DisplayName("재시도 대상을 멤버별로 그룹화하여 메일을 발송한다")
+    void retryFailedEmails_success() {
+        // given
+        final Member member1 = mock(Member.class);
+        final Email email1 = Email.from("user1@test.com");
+        given(member1.getEmail()).willReturn(email1);
+
+        final Review review1 = mock(Review.class);
+        given(review1.getMember()).willReturn(member1);
+        given(review1.getUrl()).willReturn(ReviewURL.from("url1"));
+
+        final ReviewCycle cycle1 = mock(ReviewCycle.class);
+        given(cycle1.getId()).willReturn(1L);
+        given(cycle1.getReview()).willReturn(review1);
+
+        final ReviewCycle cycle2 = mock(ReviewCycle.class);
+        given(cycle2.getId()).willReturn(2L);
+        given(cycle2.getReview()).willReturn(review1);
+
+        given(reviewCycleRepository.findAllRetryableCycles(any(Long.class), any()))
+                .willReturn(List.of(cycle1, cycle2));
+
+        // when
+        emailRetryService.retryFailedEmails();
+
+        // then
+        verify(singleReviewEmailSender, times(1)).sendOne(argThat(element ->
+                element.email().equals(email1) &&
+                        element.reviewCycleIds().containsAll(List.of(1L, 2L)) &&
+                        element.targetUrls().size() == 2
+        ));
+    }
+}

--- a/src/test/java/com/recyclestudy/email/EmailRetryServiceTest.java
+++ b/src/test/java/com/recyclestudy/email/EmailRetryServiceTest.java
@@ -39,7 +39,7 @@ class EmailRetryServiceTest {
     @DisplayName("재시도 대상이 없으면 아무 동작도 하지 않는다")
     void retryFailedEmails_noData() {
         // given
-        given(reviewCycleRepository.findAllRetryableCycles(any(Long.class), any())).willReturn(Collections.emptyList());
+        given(reviewCycleRepository.findAllRetryableCycles(any(Long.class))).willReturn(Collections.emptyList());
 
         // when
         emailRetryService.retryFailedEmails();
@@ -68,7 +68,7 @@ class EmailRetryServiceTest {
         given(cycle2.getId()).willReturn(2L);
         given(cycle2.getReview()).willReturn(review1);
 
-        given(reviewCycleRepository.findAllRetryableCycles(any(Long.class), any()))
+        given(reviewCycleRepository.findAllRetryableCycles(any(Long.class)))
                 .willReturn(List.of(cycle1, cycle2));
 
         // when

--- a/src/test/java/com/recyclestudy/email/ReviewEmailSenderTest.java
+++ b/src/test/java/com/recyclestudy/email/ReviewEmailSenderTest.java
@@ -1,32 +1,26 @@
 package com.recyclestudy.email;
 
 import com.recyclestudy.member.domain.Email;
-import com.recyclestudy.review.domain.NotificationStatus;
 import com.recyclestudy.review.domain.ReviewURL;
-import com.recyclestudy.review.service.NotificationHistoryService;
 import com.recyclestudy.review.service.ReviewCycleService;
 import com.recyclestudy.review.service.output.ReviewSendOutput;
 import com.recyclestudy.review.service.output.ReviewSendOutput.ReviewSendElement;
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.thymeleaf.TemplateEngine;
-import org.thymeleaf.context.Context;
 
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.junit.jupiter.api.Assertions.assertTimeout;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -35,16 +29,10 @@ import static org.mockito.Mockito.verify;
 class ReviewEmailSenderTest {
 
     @Mock
-    EmailSender emailSender;
-
-    @Mock
-    TemplateEngine templateEngine;
+    SingleReviewEmailSender singleReviewEmailSender;
 
     @Mock
     ReviewCycleService reviewCycleService;
-
-    @Mock
-    NotificationHistoryService notificationHistoryService;
 
     @Spy
     Clock clock = Clock.fixed(Instant.parse("2025-01-01T08:00:00Z"), ZoneId.of("UTC"));
@@ -53,7 +41,7 @@ class ReviewEmailSenderTest {
     ReviewEmailSender reviewEmailSender;
 
     @Test
-    @DisplayName("복습 대상자에게 메일을 발송한다")
+    @DisplayName("복습 대상자에게 비동기 메일 발송을 요청한다")
     void sendReviewMail_success() {
         // given
         final Email targetEmail = Email.from("user@test.com");
@@ -66,21 +54,16 @@ class ReviewEmailSenderTest {
         final ReviewSendOutput output = new ReviewSendOutput(List.of(element));
 
         given(reviewCycleService.findTargetReviewCycle(any())).willReturn(output);
-        given(templateEngine.process(eq("review_email"), any(Context.class))).willReturn("<html>복습 목록</html>");
 
         // when
         reviewEmailSender.sendReviewMail();
 
         // then
-        verify(emailSender).send(
-                eq(targetEmail),
-                eq("[Recycle Study] 오늘의 복습 목록이 도착했습니다"),
-                eq("<html>복습 목록</html>")
-        );
+        verify(singleReviewEmailSender).sendOne(element);
     }
 
     @Test
-    @DisplayName("여러 대상자에게 각각 메일을 발송한다")
+    @DisplayName("여러 대상자에게 각각 비동기 요청을 보낸다")
     void sendReviewMail_multipleRecipients() {
         // given
         final ReviewSendElement element1 = ReviewSendElement.of(
@@ -96,19 +79,18 @@ class ReviewEmailSenderTest {
         final ReviewSendOutput output = new ReviewSendOutput(List.of(element1, element2));
 
         given(reviewCycleService.findTargetReviewCycle(any())).willReturn(output);
-        given(templateEngine.process(eq("review_email"), any(Context.class))).willReturn("<html></html>");
 
         // when
         reviewEmailSender.sendReviewMail();
 
         // then
-        verify(emailSender, times(2)).send(any(Email.class), any(), any());
-        verify(emailSender).send(eq(Email.from("user1@test.com")), any(), any());
-        verify(emailSender).send(eq(Email.from("user2@test.com")), any(), any());
+        verify(singleReviewEmailSender, times(2)).sendOne(any());
+        verify(singleReviewEmailSender).sendOne(element1);
+        verify(singleReviewEmailSender).sendOne(element2);
     }
 
     @Test
-    @DisplayName("복습 대상이 없으면 메일을 발송하지 않는다")
+    @DisplayName("복습 대상이 없으면 요청을 보내지 않는다")
     void sendReviewMail_noRecipients() {
         // given
         final ReviewSendOutput output = new ReviewSendOutput(List.of());
@@ -119,83 +101,24 @@ class ReviewEmailSenderTest {
         reviewEmailSender.sendReviewMail();
 
         // then
-        verify(emailSender, never()).send(any(Email.class), any(), any());
+        verify(singleReviewEmailSender, never()).sendOne(any());
     }
 
     @Test
-    @DisplayName("템플릿에 복습 URL 목록이 전달된다")
-    void sendReviewMail_templateReceivesUrls() {
+    @DisplayName("메일 발송은 비동기적으로 처리되어 전체 시간이 지연되지 않아야 한다 (Non-blocking Expectation)")
+    void sendReviewMail_executesAsynchronously() {
         // given
-        final List<Long> reviewCycleIds = List.of(1L, 2L);
-        final List<ReviewURL> targetUrls = List.of(
-                ReviewURL.from("https://example.com/article1"),
-                ReviewURL.from("https://example.com/article2")
-        );
-        final ReviewSendElement element = ReviewSendElement.of(Email.from("user@test.com"), reviewCycleIds, targetUrls);
-        final ReviewSendOutput output = new ReviewSendOutput(List.of(element));
-        final ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
+        final ReviewSendElement user1 = ReviewSendElement.of(Email.from("user1@test.com"), List.of(1L), List.of());
+        final ReviewSendElement user2 = ReviewSendElement.of(Email.from("user2@test.com"), List.of(2L), List.of());
+        final ReviewSendOutput output = new ReviewSendOutput(List.of(user1, user2));
 
         given(reviewCycleService.findTargetReviewCycle(any())).willReturn(output);
-        given(templateEngine.process(eq("review_email"), any(Context.class))).willReturn("<html></html>");
-
-        // when
-        reviewEmailSender.sendReviewMail();
 
         // then
-        verify(templateEngine).process(eq("review_email"), contextCaptor.capture());
+        assertTimeout(Duration.ofMillis(100), () -> {
+            reviewEmailSender.sendReviewMail();
+        }, "메일 발송 요청은 즉시 완료되어야 합니다.");
 
-        final Context capturedContext = contextCaptor.getValue();
-        final List<ReviewURL> capturedUrls = (List<ReviewURL>) capturedContext.getVariable("targetUrls");
-
-        assertSoftly(softAssertions -> {
-            softAssertions.assertThat(capturedUrls).hasSize(2);
-            softAssertions.assertThat(capturedUrls.getFirst().getValue()).isEqualTo("https://example.com/article1");
-            softAssertions.assertThat(capturedUrls.get(1).getValue()).isEqualTo("https://example.com/article2");
-        });
-    }
-
-    @Test
-    @DisplayName("메일 발송 성공 시 SENT 상태로 저장한다")
-    void sendReviewMail_success_savesSentStatus() {
-        // given
-        final List<Long> reviewCycleIds = List.of(1L, 2L);
-        final ReviewSendElement element = ReviewSendElement.of(
-                Email.from("user@test.com"),
-                reviewCycleIds,
-                List.of(ReviewURL.from("https://example.com/article"))
-        );
-        final ReviewSendOutput output = new ReviewSendOutput(List.of(element));
-
-        given(reviewCycleService.findTargetReviewCycle(any())).willReturn(output);
-        given(templateEngine.process(eq("review_email"), any(Context.class))).willReturn("<html></html>");
-
-        // when
-        reviewEmailSender.sendReviewMail();
-
-        // then
-        verify(notificationHistoryService).saveAll(reviewCycleIds, NotificationStatus.SENT);
-    }
-
-    @Test
-    @DisplayName("메일 발송 실패 시 FAILED 상태로 저장한다")
-    void sendReviewMail_failure_savesFailedStatus() {
-        // given
-        final List<Long> reviewCycleIds = List.of(1L, 2L);
-        final ReviewSendElement element = ReviewSendElement.of(
-                Email.from("user@test.com"),
-                reviewCycleIds,
-                List.of(ReviewURL.from("https://example.com/article"))
-        );
-        final ReviewSendOutput output = new ReviewSendOutput(List.of(element));
-
-        given(reviewCycleService.findTargetReviewCycle(any())).willReturn(output);
-        given(templateEngine.process(eq("review_email"), any(Context.class))).willReturn("<html></html>");
-        willThrow(new RuntimeException("메일 발송 실패")).given(emailSender).send(any(), any(), any());
-
-        // when
-        reviewEmailSender.sendReviewMail();
-
-        // then
-        verify(notificationHistoryService).saveAll(reviewCycleIds, NotificationStatus.FAILED);
+        verify(singleReviewEmailSender, times(2)).sendOne(any());
     }
 }

--- a/src/test/java/com/recyclestudy/email/ReviewEmailSenderTest.java
+++ b/src/test/java/com/recyclestudy/email/ReviewEmailSenderTest.java
@@ -104,21 +104,4 @@ class ReviewEmailSenderTest {
         verify(singleReviewEmailSender, never()).sendOne(any());
     }
 
-    @Test
-    @DisplayName("메일 발송은 비동기적으로 처리되어 전체 시간이 지연되지 않아야 한다 (Non-blocking Expectation)")
-    void sendReviewMail_executesAsynchronously() {
-        // given
-        final ReviewSendElement user1 = ReviewSendElement.of(Email.from("user1@test.com"), List.of(1L), List.of());
-        final ReviewSendElement user2 = ReviewSendElement.of(Email.from("user2@test.com"), List.of(2L), List.of());
-        final ReviewSendOutput output = new ReviewSendOutput(List.of(user1, user2));
-
-        given(reviewCycleService.findTargetReviewCycle(any())).willReturn(output);
-
-        // then
-        assertTimeout(Duration.ofMillis(100), () -> {
-            reviewEmailSender.sendReviewMail();
-        }, "메일 발송 요청은 즉시 완료되어야 합니다.");
-
-        verify(singleReviewEmailSender, times(2)).sendOne(any());
-    }
 }

--- a/src/test/java/com/recyclestudy/email/SingleReviewEmailSenderTest.java
+++ b/src/test/java/com/recyclestudy/email/SingleReviewEmailSenderTest.java
@@ -1,0 +1,104 @@
+package com.recyclestudy.email;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verify;
+
+import com.recyclestudy.member.domain.Email;
+import com.recyclestudy.review.domain.NotificationStatus;
+import com.recyclestudy.review.domain.ReviewURL;
+import com.recyclestudy.review.service.NotificationHistoryService;
+import com.recyclestudy.review.service.output.ReviewSendOutput.ReviewSendElement;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+@ExtendWith(MockitoExtension.class)
+class SingleReviewEmailSenderTest {
+
+    @Mock
+    private EmailSender emailSender;
+
+    @Mock
+    private TemplateEngine templateEngine;
+
+    @Mock
+    private NotificationHistoryService notificationHistoryService;
+
+    @InjectMocks
+    private SingleReviewEmailSender singleReviewEmailSender;
+
+    @Test
+    @DisplayName("복습 대상 한 명에게 메일을 발송하고 성공 상태를 저장한다")
+    void sendOne_success() {
+        // given
+        final Email email = Email.from("user@test.com");
+        final List<Long> ids = List.of(1L, 2L);
+        final List<ReviewURL> urls = List.of(ReviewURL.from("https://example.com"));
+        final ReviewSendElement element = ReviewSendElement.of(email, ids, urls);
+
+        given(templateEngine.process(eq("review_email"), any(Context.class))).willReturn("<html></html>");
+
+        // when
+        singleReviewEmailSender.sendOne(element);
+
+        // then
+        verify(emailSender).send(eq(email), eq("[Recycle Study] 오늘의 복습 목록이 도착했습니다"), any());
+        verify(notificationHistoryService).saveAll(ids, NotificationStatus.SENT);
+    }
+
+    @Test
+    @DisplayName("메일 발송 실패 시 실패 상태를 저장한다")
+    void sendOne_failure() {
+        // given
+        final Email email = Email.from("user@test.com");
+        final List<Long> ids = List.of(1L);
+        final ReviewSendElement element = ReviewSendElement.of(email, ids, List.of());
+
+        given(templateEngine.process(any(), any())).willReturn("<html></html>");
+        willThrow(new RuntimeException("SMTP error")).given(emailSender).send(any(), any(), any());
+
+        // when
+        singleReviewEmailSender.sendOne(element);
+
+        // then
+        verify(notificationHistoryService).saveAll(ids, NotificationStatus.FAILED);
+    }
+
+    @Test
+    @DisplayName("템플릿 엔진에 올바른 변수가 전달된다")
+    void sendOne_templateVariables() {
+        // given
+        final List<ReviewURL> urls = List.of(
+                ReviewURL.from("https://link1.com"),
+                ReviewURL.from("https://link2.com")
+        );
+        final ReviewSendElement element = ReviewSendElement.of(Email.from("user@test.com"), List.of(1L), urls);
+        final ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
+
+        given(templateEngine.process(eq("review_email"), contextCaptor.capture())).willReturn("<html></html>");
+
+        // when
+        singleReviewEmailSender.sendOne(element);
+
+        // then
+        final Context context = contextCaptor.getValue();
+        final List<ReviewURL> targetUrls = (List<ReviewURL>) context.getVariable("targetUrls");
+
+        assertSoftly(softly -> {
+            softly.assertThat(targetUrls).hasSize(2);
+            softly.assertThat(targetUrls.get(0).getValue()).isEqualTo("https://link1.com");
+            softly.assertThat(targetUrls.get(1).getValue()).isEqualTo("https://link2.com");
+        });
+    }
+}

--- a/src/test/java/com/recyclestudy/email/SingleReviewEmailSenderTest.java
+++ b/src/test/java/com/recyclestudy/email/SingleReviewEmailSenderTest.java
@@ -1,12 +1,5 @@
 package com.recyclestudy.email;
 
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willThrow;
-import static org.mockito.Mockito.verify;
-
 import com.recyclestudy.member.domain.Email;
 import com.recyclestudy.review.domain.NotificationStatus;
 import com.recyclestudy.review.domain.ReviewURL;
@@ -22,6 +15,14 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class SingleReviewEmailSenderTest {
@@ -65,7 +66,7 @@ class SingleReviewEmailSenderTest {
         final List<Long> ids = List.of(1L);
         final ReviewSendElement element = ReviewSendElement.of(email, ids, List.of());
 
-        given(templateEngine.process(any(), any())).willReturn("<html></html>");
+        given(templateEngine.process(anyString(), any())).willReturn("<html></html>");
         willThrow(new RuntimeException("SMTP error")).given(emailSender).send(any(), any(), any());
 
         // when

--- a/src/test/java/com/recyclestudy/review/repository/ReviewCycleRepositoryTest.java
+++ b/src/test/java/com/recyclestudy/review/repository/ReviewCycleRepositoryTest.java
@@ -1,0 +1,105 @@
+package com.recyclestudy.review.repository;
+
+import com.recyclestudy.member.domain.Email;
+import com.recyclestudy.member.domain.Member;
+import com.recyclestudy.member.repository.MemberRepository;
+import com.recyclestudy.review.domain.NotificationHistory;
+import com.recyclestudy.review.domain.NotificationStatus;
+import com.recyclestudy.review.domain.Review;
+import com.recyclestudy.review.domain.ReviewCycle;
+import com.recyclestudy.review.domain.ReviewURL;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class ReviewCycleRepositoryTest {
+
+    @Autowired
+    private ReviewCycleRepository reviewCycleRepository;
+
+    @Autowired
+    private NotificationHistoryRepository notificationHistoryRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ReviewRepository reviewRepository;
+
+    @Test
+    @DisplayName("재시도 대상(실패 이력만 있고 최대 횟수 미만)을 조회한다")
+    void findAllRetryableCycles_success() {
+        // given
+        final Member member = memberRepository.save(Member.withoutId(Email.from("test@email.com")));
+        final Review review = reviewRepository.save(Review.withoutId(member, ReviewURL.from("url")));
+        final ReviewCycle cycle = reviewCycleRepository.save(ReviewCycle.withoutId(review, LocalDateTime.now()));
+
+        // 실패 이력 1회 저장
+        notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.FAILED));
+
+        // when
+        final List<ReviewCycle> results = reviewCycleRepository.findAllRetryableCycles(3, NotificationStatus.SENT);
+
+        // then
+        assertThat(results).hasSize(1);
+        assertThat(results.getFirst().getId()).isEqualTo(cycle.getId());
+    }
+
+    @Test
+    @DisplayName("이미 성공한 이력이 있으면 재시도 대상이 아니다")
+    void findAllRetryableCycles_alreadySent() {
+        // given
+        final Member member = memberRepository.save(Member.withoutId(Email.from("sent@email.com")));
+        final Review review = reviewRepository.save(Review.withoutId(member, ReviewURL.from("url")));
+        final ReviewCycle cycle = reviewCycleRepository.save(ReviewCycle.withoutId(review, LocalDateTime.now()));
+
+        notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.FAILED));
+        notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.SENT));
+
+        // when
+        final List<ReviewCycle> results = reviewCycleRepository.findAllRetryableCycles(3, NotificationStatus.SENT);
+
+        // then
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    @DisplayName("최대 재시도 횟수에 도달하면 재시도 대상이 아니다")
+    void findAllRetryableCycles_maxRetryReached() {
+        // given
+        final Member member = memberRepository.save(Member.withoutId(Email.from("max@email.com")));
+        final Review review = reviewRepository.save(Review.withoutId(member, ReviewURL.from("url")));
+        final ReviewCycle cycle = reviewCycleRepository.save(ReviewCycle.withoutId(review, LocalDateTime.now()));
+
+        notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.FAILED));
+        notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.FAILED));
+        notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.FAILED));
+
+        // when
+        final List<ReviewCycle> results = reviewCycleRepository.findAllRetryableCycles(3, NotificationStatus.SENT);
+
+        // then
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    @DisplayName("전송 시도 이력이 없는 경우 재시도 대상이 아니다")
+    void findAllRetryableCycles_noHistory() {
+        // given
+        final Member member = memberRepository.save(Member.withoutId(Email.from("new@email.com")));
+        final Review review = reviewRepository.save(Review.withoutId(member, ReviewURL.from("url")));
+        reviewCycleRepository.save(ReviewCycle.withoutId(review, LocalDateTime.now()));
+
+        // when
+        final List<ReviewCycle> results = reviewCycleRepository.findAllRetryableCycles(3, NotificationStatus.SENT);
+
+        // then
+        assertThat(results).isEmpty();
+    }
+}

--- a/src/test/java/com/recyclestudy/review/repository/ReviewCycleRepositoryTest.java
+++ b/src/test/java/com/recyclestudy/review/repository/ReviewCycleRepositoryTest.java
@@ -40,15 +40,32 @@ class ReviewCycleRepositoryTest {
         final Review review = reviewRepository.save(Review.withoutId(member, ReviewURL.from("url")));
         final ReviewCycle cycle = reviewCycleRepository.save(ReviewCycle.withoutId(review, LocalDateTime.now()));
 
-        // 실패 이력 1회 저장
+        notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.PENDING));
         notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.FAILED));
 
         // when
-        final List<ReviewCycle> results = reviewCycleRepository.findAllRetryableCycles(3, NotificationStatus.SENT);
+        final List<ReviewCycle> results = reviewCycleRepository.findAllRetryableCycles(3);
 
         // then
         assertThat(results).hasSize(1);
-        assertThat(results.getFirst().getId()).isEqualTo(cycle.getId());
+        assertThat(results.get(0).getId()).isEqualTo(cycle.getId());
+    }
+
+    @Test
+    @DisplayName("PENDING 상태만 있는 경우는 재시도 대상이 아니다")
+    void findAllRetryableCycles_pendingOnly() {
+        // given
+        final Member member = memberRepository.save(Member.withoutId(Email.from("pending@email.com")));
+        final Review review = reviewRepository.save(Review.withoutId(member, ReviewURL.from("url")));
+        final ReviewCycle cycle = reviewCycleRepository.save(ReviewCycle.withoutId(review, LocalDateTime.now()));
+
+        notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.PENDING));
+
+        // when
+        final List<ReviewCycle> results = reviewCycleRepository.findAllRetryableCycles(3);
+
+        // then
+        assertThat(results).isEmpty();
     }
 
     @Test
@@ -59,11 +76,12 @@ class ReviewCycleRepositoryTest {
         final Review review = reviewRepository.save(Review.withoutId(member, ReviewURL.from("url")));
         final ReviewCycle cycle = reviewCycleRepository.save(ReviewCycle.withoutId(review, LocalDateTime.now()));
 
+        notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.PENDING));
         notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.FAILED));
         notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.SENT));
 
         // when
-        final List<ReviewCycle> results = reviewCycleRepository.findAllRetryableCycles(3, NotificationStatus.SENT);
+        final List<ReviewCycle> results = reviewCycleRepository.findAllRetryableCycles(3);
 
         // then
         assertThat(results).isEmpty();
@@ -77,19 +95,20 @@ class ReviewCycleRepositoryTest {
         final Review review = reviewRepository.save(Review.withoutId(member, ReviewURL.from("url")));
         final ReviewCycle cycle = reviewCycleRepository.save(ReviewCycle.withoutId(review, LocalDateTime.now()));
 
+        notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.PENDING));
         notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.FAILED));
         notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.FAILED));
         notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.FAILED));
 
         // when
-        final List<ReviewCycle> results = reviewCycleRepository.findAllRetryableCycles(3, NotificationStatus.SENT);
+        final List<ReviewCycle> results = reviewCycleRepository.findAllRetryableCycles(3);
 
         // then
         assertThat(results).isEmpty();
     }
 
     @Test
-    @DisplayName("전송 시도 이력이 없는 경우 재시도 대상이 아니다")
+    @DisplayName("이력이 없는 경우 재시도 대상이 아니다")
     void findAllRetryableCycles_noHistory() {
         // given
         final Member member = memberRepository.save(Member.withoutId(Email.from("new@email.com")));
@@ -97,7 +116,7 @@ class ReviewCycleRepositoryTest {
         reviewCycleRepository.save(ReviewCycle.withoutId(review, LocalDateTime.now()));
 
         // when
-        final List<ReviewCycle> results = reviewCycleRepository.findAllRetryableCycles(3, NotificationStatus.SENT);
+        final List<ReviewCycle> results = reviewCycleRepository.findAllRetryableCycles(3);
 
         // then
         assertThat(results).isEmpty();

--- a/src/test/java/com/recyclestudy/review/service/ReviewCycleServiceTest.java
+++ b/src/test/java/com/recyclestudy/review/service/ReviewCycleServiceTest.java
@@ -9,9 +9,7 @@ import com.recyclestudy.review.repository.ReviewCycleRepository;
 import com.recyclestudy.review.service.input.ReviewSendInput;
 import com.recyclestudy.review.service.output.ReviewSendOutput;
 import com.recyclestudy.review.service.output.ReviewSendOutput.ReviewSendElement;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,10 +37,7 @@ class ReviewCycleServiceTest {
     void findTargetReviewCycle_success() {
         // given
         final LocalDateTime scheduledAt = LocalDateTime.of(2025, 1, 1, 8, 0);
-        final ReviewSendInput input = ReviewSendInput.from(
-                LocalDate.of(2025, 1, 1),
-                LocalTime.of(8, 0)
-        );
+        final ReviewSendInput input = ReviewSendInput.from(scheduledAt);
 
         final Member member = Member.withoutId(Email.from("user@test.com"));
         final Review review = Review.withoutId(member, ReviewURL.from("https://example.com/article"));
@@ -66,10 +61,7 @@ class ReviewCycleServiceTest {
     void findTargetReviewCycle_empty() {
         // given
         final LocalDateTime scheduledAt = LocalDateTime.of(2025, 1, 1, 8, 0);
-        final ReviewSendInput input = ReviewSendInput.from(
-                LocalDate.of(2025, 1, 1),
-                LocalTime.of(8, 0)
-        );
+        final ReviewSendInput input = ReviewSendInput.from(scheduledAt);
 
         given(reviewCycleRepository.findAllByScheduledAt(scheduledAt)).willReturn(List.of());
 
@@ -85,10 +77,7 @@ class ReviewCycleServiceTest {
     void findTargetReviewCycle_groupByEmail() {
         // given
         final LocalDateTime scheduledAt = LocalDateTime.of(2025, 1, 1, 8, 0);
-        final ReviewSendInput input = ReviewSendInput.from(
-                LocalDate.of(2025, 1, 1),
-                LocalTime.of(8, 0)
-        );
+        final ReviewSendInput input = ReviewSendInput.from(scheduledAt);
 
         final Member member = Member.withoutId(Email.from("user@test.com"));
         final Review review1 = Review.withoutId(member, ReviewURL.from("https://example.com/article1"));
@@ -116,10 +105,7 @@ class ReviewCycleServiceTest {
     void findTargetReviewCycle_multipleUsers() {
         // given
         final LocalDateTime scheduledAt = LocalDateTime.of(2025, 1, 1, 8, 0);
-        final ReviewSendInput input = ReviewSendInput.from(
-                LocalDate.of(2025, 1, 1),
-                LocalTime.of(8, 0)
-        );
+        final ReviewSendInput input = ReviewSendInput.from(scheduledAt);
 
         final Member member1 = Member.withoutId(Email.from("user1@test.com"));
         final Member member2 = Member.withoutId(Email.from("user2@test.com"));

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -29,3 +29,7 @@ spring:
 
 auth:
   base-url: http://localhost:8080
+
+schedule:
+  review-mail:
+    cron: "-"


### PR DESCRIPTION
<!-- PR 템플릿 -->

## 🚀 작업 내용

이메일 전송 실패 시 안정적인 알림 전달을 위해 재시도 메커니즘 구현

- `ReviewCycleRepository`
  - `findAllRetryableCycles` 쿼리 메서드 추가
  - `NotificationHistory`를 조인하여 '실패 이력은 있지만 성공 이력이 없고, 재시도 횟수가 3회 미만인' 복습 주기 조회
- `EmailRetryService`
  - 기존 `SingleReviewEmailSender`를 재사용하여 재전송 시에도 성공/실패 여부가 `NotificationHistory`에 자동으로 기록되도록 처리
- `EmailRetryScheduler`
  - 1분 간격으로 재시도 로직이 실행되도록 설정

## 📸 이슈 번호

- close #55 

## ✍ 궁금한 점

- `NotificationHistory`에 저장하는 것조차 실패하는 것을 방지하는 방법이 있을까?