### PR TITLE
멤버 알림 시간 설정 변경 기능 추가

### DIFF
--- a/src/main/java/com/recyclestudy/member/controller/MemberController.java
+++ b/src/main/java/com/recyclestudy/member/controller/MemberController.java
@@ -2,12 +2,14 @@ package com.recyclestudy.member.controller;
 
 import com.recyclestudy.common.annotation.AuthDevice;
 import com.recyclestudy.email.DeviceAuthEmailSender;
+import com.recyclestudy.member.controller.request.MemberNotificationTimeUpdateRequest;
 import com.recyclestudy.member.controller.request.MemberSaveRequest;
 import com.recyclestudy.member.controller.response.MemberFindResponse;
 import com.recyclestudy.member.controller.response.MemberSaveResponse;
 import com.recyclestudy.member.domain.DeviceIdentifier;
 import com.recyclestudy.member.service.MemberService;
 import com.recyclestudy.member.service.input.MemberFindInput;
+import com.recyclestudy.member.service.input.MemberNotificationTimeUpdateInput;
 import com.recyclestudy.member.service.input.MemberSaveInput;
 import com.recyclestudy.member.service.output.MemberFindOutput;
 import com.recyclestudy.member.service.output.MemberSaveOutput;
@@ -15,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -50,5 +53,15 @@ public class MemberController {
         final MemberFindOutput output = memberService.findAllMemberDevices(input);
         final MemberFindResponse response = MemberFindResponse.from(output);
         return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/notification-time")
+    public ResponseEntity<Void> updateNotificationTime(
+            @RequestBody final MemberNotificationTimeUpdateRequest request,
+            @AuthDevice final DeviceIdentifier identifier
+    ) {
+        final MemberNotificationTimeUpdateInput input = request.toInput(identifier);
+        memberService.updateNotificationTime(input);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/recyclestudy/member/controller/request/MemberNotificationTimeUpdateRequest.java
+++ b/src/main/java/com/recyclestudy/member/controller/request/MemberNotificationTimeUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.recyclestudy.member.controller.request;
+
+import com.recyclestudy.member.domain.DeviceIdentifier;
+import com.recyclestudy.member.service.input.MemberNotificationTimeUpdateInput;
+import java.time.LocalTime;
+
+public record MemberNotificationTimeUpdateRequest(LocalTime notificationTime) {
+
+    public MemberNotificationTimeUpdateInput toInput(final DeviceIdentifier identifier) {
+        return MemberNotificationTimeUpdateInput.of(identifier, notificationTime);
+    }
+}

--- a/src/main/java/com/recyclestudy/member/controller/response/MemberFindResponse.java
+++ b/src/main/java/com/recyclestudy/member/controller/response/MemberFindResponse.java
@@ -2,16 +2,17 @@ package com.recyclestudy.member.controller.response;
 
 import com.recyclestudy.member.service.output.MemberFindOutput;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 
-public record MemberFindResponse(String email, List<MemberFindElement> devices) {
+public record MemberFindResponse(String email, LocalTime notificationTime, List<MemberFindElement> devices) {
 
     public static MemberFindResponse from(final MemberFindOutput output) {
         final List<MemberFindElement> memberFindElements = output.elements().stream()
                 .map(outputElement -> new MemberFindElement(outputElement.identifier().getValue(),
                         outputElement.createdAt()))
                 .toList();
-        return new MemberFindResponse(output.email().getValue(), memberFindElements);
+        return new MemberFindResponse(output.email().getValue(), output.notificationTime(), memberFindElements);
     }
 
     private record MemberFindElement(String identifier, LocalDateTime createdAt) {

--- a/src/main/java/com/recyclestudy/member/domain/Member.java
+++ b/src/main/java/com/recyclestudy/member/domain/Member.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import java.time.LocalTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -25,9 +26,12 @@ public class Member extends BaseEntity {
     @AttributeOverride(name = "value", column = @Column(name = "email", nullable = false, unique = true))
     private Email email;
 
+    @Column(name = "notification_time")
+    private LocalTime notificationTime;
+
     public static Member withoutId(final Email email) {
         validateNotNull(email);
-        return new Member(email);
+        return new Member(email, null);
     }
 
     private static void validateNotNull(final Email email) {
@@ -38,5 +42,9 @@ public class Member extends BaseEntity {
 
     public boolean hasEmail(final Email email) {
         return this.email.equals(email);
+    }
+
+    public void updateNotificationTime(final LocalTime notificationTime) {
+        this.notificationTime = notificationTime;
     }
 }

--- a/src/main/java/com/recyclestudy/member/service/MemberService.java
+++ b/src/main/java/com/recyclestudy/member/service/MemberService.java
@@ -95,9 +95,11 @@ public class MemberService {
     public void updateNotificationTime(final MemberNotificationTimeUpdateInput input) {
         final Member member = memberRepository.findByIdentifier(input.identifier())
                 .orElseThrow(() -> new UnauthorizedException("유효하지 않은 디바이스입니다"));
+        final LocalTime previousNotificationTime = member.getNotificationTime();
+
         member.updateNotificationTime(input.notificationTime());
         log.info("[MEMBER_NOTI_TIME_UPDATED] 멤버 알림 시간 변경: memberId={}, from={}, to={}",
-                member.getId(), member.getNotificationTime(), input.notificationTime());
+                member.getId(), previousNotificationTime, input.notificationTime());
     }
 
     private Member saveNewMember(final Email email) {

--- a/src/main/java/com/recyclestudy/member/service/MemberService.java
+++ b/src/main/java/com/recyclestudy/member/service/MemberService.java
@@ -2,6 +2,7 @@ package com.recyclestudy.member.service;
 
 import com.recyclestudy.exception.BadRequestException;
 import com.recyclestudy.exception.NotFoundException;
+import com.recyclestudy.exception.UnauthorizedException;
 import com.recyclestudy.member.domain.ActivationExpiredDateTime;
 import com.recyclestudy.member.domain.Device;
 import com.recyclestudy.member.domain.DeviceIdentifier;
@@ -11,15 +12,18 @@ import com.recyclestudy.member.repository.DeviceRepository;
 import com.recyclestudy.member.repository.MemberRepository;
 import com.recyclestudy.member.service.input.DeviceDeleteInput;
 import com.recyclestudy.member.service.input.MemberFindInput;
+import com.recyclestudy.member.service.input.MemberNotificationTimeUpdateInput;
 import com.recyclestudy.member.service.input.MemberSaveInput;
 import com.recyclestudy.member.service.output.MemberFindOutput;
 import com.recyclestudy.member.service.output.MemberSaveOutput;
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -50,7 +54,18 @@ public class MemberService {
     @Transactional(readOnly = true)
     public MemberFindOutput findAllMemberDevices(final MemberFindInput input) {
         final List<Device> devices = deviceRepository.findAllByMemberEmail(input.email());
-        return MemberFindOutput.of(input.email(), devices);
+        final LocalTime notificationTime = findNotificationTime(input.email(), devices);
+        return MemberFindOutput.of(input.email(), notificationTime, devices);
+    }
+
+    @Nullable
+    private LocalTime findNotificationTime(final Email email, final List<Device> devices) {
+        if (devices.isEmpty()) {
+            return memberRepository.findByEmail(email)
+                    .map(Member::getNotificationTime)
+                    .orElse(null);
+        }
+        return devices.getFirst().getMember().getNotificationTime();
     }
 
     @Transactional
@@ -74,6 +89,15 @@ public class MemberService {
     public void deleteDevice(final DeviceDeleteInput input) {
         deviceRepository.deleteByIdentifier(input.targetDeviceIdentifier());
         log.info("[DEVICE_DELETED] 디바이스 삭제 성공: {}", input.targetDeviceIdentifier());
+    }
+
+    @Transactional
+    public void updateNotificationTime(final MemberNotificationTimeUpdateInput input) {
+        final Member member = memberRepository.findByIdentifier(input.identifier())
+                .orElseThrow(() -> new UnauthorizedException("유효하지 않은 디바이스입니다"));
+        member.updateNotificationTime(input.notificationTime());
+        log.info("[MEMBER_NOTI_TIME_UPDATED] 멤버 알림 시간 변경: memberId={}, from={}, to={}",
+                member.getId(), member.getNotificationTime(), input.notificationTime());
     }
 
     private Member saveNewMember(final Email email) {

--- a/src/main/java/com/recyclestudy/member/service/input/MemberNotificationTimeUpdateInput.java
+++ b/src/main/java/com/recyclestudy/member/service/input/MemberNotificationTimeUpdateInput.java
@@ -1,0 +1,11 @@
+package com.recyclestudy.member.service.input;
+
+import com.recyclestudy.member.domain.DeviceIdentifier;
+import java.time.LocalTime;
+
+public record MemberNotificationTimeUpdateInput(DeviceIdentifier identifier, LocalTime notificationTime) {
+
+    public static MemberNotificationTimeUpdateInput of(final DeviceIdentifier identifier, final LocalTime notificationTime) {
+        return new MemberNotificationTimeUpdateInput(identifier, notificationTime);
+    }
+}

--- a/src/main/java/com/recyclestudy/member/service/output/MemberFindOutput.java
+++ b/src/main/java/com/recyclestudy/member/service/output/MemberFindOutput.java
@@ -4,15 +4,20 @@ import com.recyclestudy.member.domain.Device;
 import com.recyclestudy.member.domain.DeviceIdentifier;
 import com.recyclestudy.member.domain.Email;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 
-public record MemberFindOutput(Email email, List<MemberFindElement> elements) {
+public record MemberFindOutput(Email email, LocalTime notificationTime, List<MemberFindElement> elements) {
 
-    public static MemberFindOutput of(final Email email, final List<Device> devices) {
+    public static MemberFindOutput of(
+            final Email email,
+            final LocalTime notificationTime,
+            final List<Device> devices
+    ) {
         final List<MemberFindElement> memberFindElements = devices.stream()
                 .map(device -> new MemberFindElement(device.getIdentifier(), device.getCreatedAt()))
                 .toList();
-        return new MemberFindOutput(email, memberFindElements);
+        return new MemberFindOutput(email, notificationTime, memberFindElements);
     }
 
     public record MemberFindElement(DeviceIdentifier identifier, LocalDateTime createdAt) {

--- a/src/main/java/com/recyclestudy/review/service/ReviewService.java
+++ b/src/main/java/com/recyclestudy/review/service/ReviewService.java
@@ -47,7 +47,7 @@ public class ReviewService {
         final Review savedReview = reviewRepository.save(review);
         log.info("[REVIEW_SAVED] 복습 주제 저장 성공: reviewId={}", savedReview.getId());
 
-        final List<LocalDateTime> scheduledAts = calculateScheduledAts(input.cycle());
+        final List<LocalDateTime> scheduledAts = calculateScheduledAts(input.cycle(), member);
 
         final List<ReviewCycle> reviewCycles = scheduledAts.stream()
                 .map(scheduledAt -> ReviewCycle.withoutId(savedReview, scheduledAt))
@@ -65,14 +65,25 @@ public class ReviewService {
         return ReviewSaveOutput.of(savedReview.getUrl(), savedScheduledAts);
     }
 
-    private List<LocalDateTime> calculateScheduledAts(final CycleSelection cycleSelection) {
+    private List<LocalDateTime> calculateScheduledAts(final CycleSelection cycleSelection, final Member member) {
         final CycleSelection resolvedCycle = resolveDefaultCycleIfNull(cycleSelection);
         final List<Duration> durations = cycleSelectionResolverRegistry.resolve(resolvedCycle);
         final LocalDateTime baseTime = LocalDateTime.now(clock).truncatedTo(ChronoUnit.MINUTES);
 
         return durations.stream()
-                .map(baseTime::plus)
+                .map(duration -> calculateScheduledAt(baseTime, duration, member))
                 .toList();
+    }
+
+    private LocalDateTime calculateScheduledAt(final LocalDateTime baseTime, final Duration duration, final Member member) {
+        final LocalDateTime scheduledAt = baseTime.plus(duration);
+        if (duration.toDays() < 1 || member.getNotificationTime() == null) {
+            return scheduledAt;
+        }
+        final LocalDateTime adjustedTime = scheduledAt.with(member.getNotificationTime()).truncatedTo(ChronoUnit.MINUTES);
+        log.info("[REVIEW_SCHEDULE_ADJUSTED] 복습 주기 시간 조정: original={}, adjusted={}, memberId={}",
+                scheduledAt, adjustedTime, member.getId());
+        return adjustedTime;
     }
 
     @Deprecated // 프론트 마이그레이션 완료 후 제거 예정

--- a/src/main/resources/db/migration/V20260206_1__add_notification_time_to_member.sql
+++ b/src/main/resources/db/migration/V20260206_1__add_notification_time_to_member.sql
@@ -1,0 +1,1 @@
+alter table member add column notification_time time;

--- a/src/test/java/com/recyclestudy/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/recyclestudy/member/controller/MemberControllerTest.java
@@ -3,6 +3,7 @@ package com.recyclestudy.member.controller;
 import com.recyclestudy.email.DeviceAuthEmailSender;
 import com.recyclestudy.exception.NotFoundException;
 import com.recyclestudy.exception.UnauthorizedException;
+import com.recyclestudy.member.controller.request.MemberNotificationTimeUpdateRequest;
 import com.recyclestudy.member.controller.request.MemberSaveRequest;
 import com.recyclestudy.member.domain.ActivationExpiredDateTime;
 import com.recyclestudy.member.domain.Device;
@@ -11,10 +12,12 @@ import com.recyclestudy.member.domain.Email;
 import com.recyclestudy.member.domain.Member;
 import com.recyclestudy.member.repository.DeviceRepository;
 import com.recyclestudy.member.service.MemberService;
+import com.recyclestudy.member.service.input.MemberNotificationTimeUpdateInput;
 import com.recyclestudy.member.service.output.MemberFindOutput;
 import com.recyclestudy.member.service.output.MemberSaveOutput;
 import com.recyclestudy.restdocs.APIBaseTest;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
@@ -118,6 +121,7 @@ class MemberControllerTest extends APIBaseTest {
 
         final MemberFindOutput output = new MemberFindOutput(
                 Email.from(email),
+                LocalTime.of(9, 0),
                 List.of(device1, device2)
         );
 
@@ -139,6 +143,8 @@ class MemberControllerTest extends APIBaseTest {
                                 )
                                 .responseFields(
                                         fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
+                                        fieldWithPath("notificationTime").type(JsonFieldType.STRING)
+                                                .description("알림 시간").optional(),
                                         fieldWithPath("devices").type(JsonFieldType.ARRAY).description("디바이스 목록"),
                                         fieldWithPath("devices[].identifier").type(JsonFieldType.STRING)
                                                 .description("디바이스 식별자 값"),
@@ -422,6 +428,7 @@ class MemberControllerTest extends APIBaseTest {
 
         final MemberFindOutput output = new MemberFindOutput(
                 Email.from(email),
+                null,
                 List.of(device1, device2)
         );
 
@@ -443,6 +450,8 @@ class MemberControllerTest extends APIBaseTest {
                                 )
                                 .responseFields(
                                         fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
+                                        fieldWithPath("notificationTime").type(JsonFieldType.STRING)
+                                                .description("알림 시간").optional(),
                                         fieldWithPath("devices").type(JsonFieldType.ARRAY).description("디바이스 목록"),
                                         fieldWithPath("devices[].identifier").type(JsonFieldType.STRING)
                                                 .description("디바이스 식별자 값"),
@@ -460,5 +469,39 @@ class MemberControllerTest extends APIBaseTest {
                 .then()
                 .statusCode(HttpStatus.OK.value())
                 .body("devices", hasSize(2));
+    }
+
+    @Test
+    @DisplayName("멤버의 알림 시간을 업데이트한다")
+    void updateNotificationTime() {
+        // given
+        final String headerIdentifier = "device-id-1";
+        final LocalTime notificationTime = LocalTime.of(9, 0);
+        final MemberNotificationTimeUpdateRequest request = new MemberNotificationTimeUpdateRequest(notificationTime);
+
+        // when
+        // then
+        given(this.spec)
+                .filter(document(DEFAULT_REST_DOC_PATH,
+                        builder()
+                                .tag("Member")
+                                .summary("멤버 알림 시간 업데이트")
+                                .description("멤버의 알림 시간을 업데이트한다")
+                                .requestHeaders(
+                                        headerWithName("X-Device-Id").description("디바이스 식별자")
+                                )
+                                .requestFields(
+                                        fieldWithPath("notificationTime").type(JsonFieldType.STRING).description("알림 시간 (HH:mm:ss)")
+                                )
+                ))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("X-Device-Id", headerIdentifier)
+                .body(request)
+                .when()
+                .patch("/api/v1/members/notification-time")
+                .then()
+                .statusCode(HttpStatus.OK.value());
+
+        verify(memberService).updateNotificationTime(any(MemberNotificationTimeUpdateInput.class));
     }
 }

--- a/src/test/java/com/recyclestudy/member/service/MemberServiceTest.java
+++ b/src/test/java/com/recyclestudy/member/service/MemberServiceTest.java
@@ -261,7 +261,6 @@ class MemberServiceTest {
             softAssertions.assertThat(member.getNotificationTime()).isNotNull();
             softAssertions.assertThat(member.getNotificationTime()).isEqualTo(notificationTime);
         });
-
     }
 
     @Test

--- a/src/test/java/com/recyclestudy/member/service/MemberServiceTest.java
+++ b/src/test/java/com/recyclestudy/member/service/MemberServiceTest.java
@@ -2,6 +2,7 @@ package com.recyclestudy.member.service;
 
 import com.recyclestudy.exception.BadRequestException;
 import com.recyclestudy.exception.NotFoundException;
+import com.recyclestudy.exception.UnauthorizedException;
 import com.recyclestudy.member.domain.ActivationExpiredDateTime;
 import com.recyclestudy.member.domain.Device;
 import com.recyclestudy.member.domain.DeviceIdentifier;
@@ -11,17 +12,18 @@ import com.recyclestudy.member.repository.DeviceRepository;
 import com.recyclestudy.member.repository.MemberRepository;
 import com.recyclestudy.member.service.input.DeviceDeleteInput;
 import com.recyclestudy.member.service.input.MemberFindInput;
+import com.recyclestudy.member.service.input.MemberNotificationTimeUpdateInput;
 import com.recyclestudy.member.service.input.MemberSaveInput;
 import com.recyclestudy.member.service.output.MemberFindOutput;
 import com.recyclestudy.member.service.output.MemberSaveOutput;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,6 +35,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
@@ -122,7 +125,7 @@ class MemberServiceTest {
         final MemberFindOutput actual = memberService.findAllMemberDevices(input);
 
         // then
-        SoftAssertions.assertSoftly(softAssertions -> {
+        assertSoftly(softAssertions -> {
             softAssertions.assertThat(actual.elements()).hasSize(1);
             softAssertions.assertThat(actual.elements().getFirst().identifier()).isEqualTo(input.deviceIdentifier());
         });
@@ -236,5 +239,46 @@ class MemberServiceTest {
 
         // then
         verify(deviceRepository).deleteByIdentifier(targetDeviceIdentifier);
+    }
+
+    @Test
+    @DisplayName("멤버의 알림 시간을 업데이트할 수 있다")
+    void updateNotificationTime() {
+        // given
+        final DeviceIdentifier identifier = DeviceIdentifier.from("device-id");
+        final LocalTime notificationTime = LocalTime.of(9, 0);
+        final MemberNotificationTimeUpdateInput input = new MemberNotificationTimeUpdateInput(identifier,
+                notificationTime);
+        final Member member = Member.withoutId(Email.from("test@test.com"));
+
+        given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.of(member));
+
+        // when
+        memberService.updateNotificationTime(input);
+
+        // then
+        assertSoftly(softAssertions -> {
+            softAssertions.assertThat(member.getNotificationTime()).isNotNull();
+            softAssertions.assertThat(member.getNotificationTime()).isEqualTo(notificationTime);
+        });
+
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 디바이스로 알림 시간 업데이트 시 예외를 던진다")
+    void updateNotificationTime_UnauthorizedDevice() {
+        // given
+        final DeviceIdentifier identifier = DeviceIdentifier.from("invalid-id");
+        final LocalTime notificationTime = LocalTime.of(9, 0);
+        final MemberNotificationTimeUpdateInput input = new MemberNotificationTimeUpdateInput(identifier,
+                notificationTime);
+
+        given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.empty());
+
+        // when
+        // then
+        assertThatThrownBy(() -> memberService.updateNotificationTime(input))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasMessage("유효하지 않은 디바이스입니다");
     }
 }

--- a/src/test/java/com/recyclestudy/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/recyclestudy/review/service/ReviewServiceTest.java
@@ -44,8 +44,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-class
-ReviewServiceTest {
+class ReviewServiceTest {
 
     @Mock
     ReviewRepository reviewRepository;

--- a/src/test/java/com/recyclestudy/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/recyclestudy/review/service/ReviewServiceTest.java
@@ -21,6 +21,7 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -43,7 +44,8 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-class ReviewServiceTest {
+class
+ReviewServiceTest {
 
     @Mock
     ReviewRepository reviewRepository;
@@ -163,5 +165,44 @@ class ReviewServiceTest {
         assertThatThrownBy(() -> reviewService.saveReview(input))
                 .isInstanceOf(UnauthorizedException.class)
                 .hasMessage("유효하지 않은 디바이스입니다");
+    }
+
+    @Test
+    @DisplayName("사용자가 선호 알림 시간을 설정한 경우 1일 이상의 주기는 해당 시간에 맞춰 조정된다")
+    void saveReview_withPreferredNotificationTime() {
+        // given
+        final DeviceIdentifier identifier = DeviceIdentifier.from("device-id");
+        final String urlValue = "https://test.com";
+        final DefaultCycleSelection cycleSelection = new DefaultCycleSelection("EBBINGHAUS");
+        final ReviewSaveInput input = ReviewSaveInput.of(identifier, urlValue, cycleSelection);
+
+        final Email email = Email.from("test@test.com");
+        final Member member = Member.withoutId(email);
+        final LocalTime preferredTime = LocalTime.of(9, 0);
+        member.updateNotificationTime(preferredTime);
+
+        final Review review = Review.withoutId(member, ReviewURL.from(urlValue));
+
+        final List<Duration> durations = List.of(Duration.ofMinutes(10), Duration.ofDays(1));
+
+        given(memberRepository.findByIdentifier(any(DeviceIdentifier.class))).willReturn(Optional.of(member));
+        given(cycleSelectionResolverRegistry.resolve(cycleSelection)).willReturn(durations);
+        given(reviewRepository.save(any(Review.class))).willReturn(review);
+
+        final ArgumentCaptor<List<ReviewCycle>> cycleCaptor = ArgumentCaptor.forClass(List.class);
+        given(reviewCycleRepository.saveAll(cycleCaptor.capture())).willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        reviewService.saveReview(input);
+
+        // then
+        final List<ReviewCycle> capturedCycles = cycleCaptor.getValue();
+        assertSoftly(softAssertions -> {
+            softAssertions.assertThat(capturedCycles).hasSize(2);
+            softAssertions.assertThat(capturedCycles.getFirst().getScheduledAt())
+                    .isEqualTo(now.plusMinutes(10));
+            softAssertions.assertThat(capturedCycles.get(1).getScheduledAt())
+                    .isEqualTo(now.plusDays(1).with(preferredTime));
+        });
     }
 }


### PR DESCRIPTION
<!-- PR 템플릿 -->

멤버가 선호하는 복습 알림 시간을 설정할 수 있는 기능 추가

## 📸 이슈 번호

- close #58 

## ✍ 궁금한 점

- `Member` 생성 시 `notificationTime`을 초기화하는 방식에 대해 고민했으나, 현재 도메인 규칙("가입 시 알림 시간 없음")을 명확히 하고자 팩토리 메서드에서 `null`을 명시적으로 다루지 않고 내부적으로 처리하는 기존 방식을 유지하였음. 추후 초기 설정이 필요해질 경우 팩토리 메서드 오버로딩으로 대응 가능하다고 판단함.
