### PR TITLE
복습 주기 하위 호환성 로직 제거

### DIFF
--- a/src/main/java/com/recyclestudy/member/service/input/MemberNotificationTimeUpdateInput.java
+++ b/src/main/java/com/recyclestudy/member/service/input/MemberNotificationTimeUpdateInput.java
@@ -5,7 +5,10 @@ import java.time.LocalTime;
 
 public record MemberNotificationTimeUpdateInput(DeviceIdentifier identifier, LocalTime notificationTime) {
 
-    public static MemberNotificationTimeUpdateInput of(final DeviceIdentifier identifier, final LocalTime notificationTime) {
+    public static MemberNotificationTimeUpdateInput of(
+            final DeviceIdentifier identifier,
+            final LocalTime notificationTime
+    ) {
         return new MemberNotificationTimeUpdateInput(identifier, notificationTime);
     }
 }

--- a/src/main/java/com/recyclestudy/review/repository/ReviewCycleRepository.java
+++ b/src/main/java/com/recyclestudy/review/repository/ReviewCycleRepository.java
@@ -1,6 +1,5 @@
 package com.recyclestudy.review.repository;
 
-import com.recyclestudy.review.domain.NotificationStatus;
 import com.recyclestudy.review.domain.ReviewCycle;
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/main/java/com/recyclestudy/review/service/ReviewService.java
+++ b/src/main/java/com/recyclestudy/review/service/ReviewService.java
@@ -2,7 +2,6 @@ package com.recyclestudy.review.service;
 
 import com.recyclestudy.common.BaseEntity;
 import com.recyclestudy.cycle.domain.selection.CycleSelection;
-import com.recyclestudy.cycle.domain.selection.DefaultCycleSelection;
 import com.recyclestudy.cycle.service.resolver.CycleSelectionResolverRegistry;
 import com.recyclestudy.exception.UnauthorizedException;
 import com.recyclestudy.member.domain.Member;
@@ -66,8 +65,7 @@ public class ReviewService {
     }
 
     private List<LocalDateTime> calculateScheduledAts(final CycleSelection cycleSelection, final Member member) {
-        final CycleSelection resolvedCycle = resolveDefaultCycleIfNull(cycleSelection);
-        final List<Duration> durations = cycleSelectionResolverRegistry.resolve(resolvedCycle);
+        final List<Duration> durations = cycleSelectionResolverRegistry.resolve(cycleSelection);
         final LocalDateTime baseTime = LocalDateTime.now(clock).truncatedTo(ChronoUnit.MINUTES);
 
         return durations.stream()
@@ -75,23 +73,20 @@ public class ReviewService {
                 .toList();
     }
 
-    private LocalDateTime calculateScheduledAt(final LocalDateTime baseTime, final Duration duration, final Member member) {
+    private LocalDateTime calculateScheduledAt(
+            final LocalDateTime baseTime,
+            final Duration duration,
+            final Member member
+    ) {
         final LocalDateTime scheduledAt = baseTime.plus(duration);
         if (duration.toDays() < 1 || member.getNotificationTime() == null) {
             return scheduledAt;
         }
-        final LocalDateTime adjustedTime = scheduledAt.with(member.getNotificationTime()).truncatedTo(ChronoUnit.MINUTES);
+        final LocalDateTime adjustedTime = scheduledAt.with(member.getNotificationTime())
+                .truncatedTo(ChronoUnit.MINUTES);
         log.info("[REVIEW_SCHEDULE_ADJUSTED] 복습 주기 시간 조정: original={}, adjusted={}, memberId={}",
                 scheduledAt, adjustedTime, member.getId());
         return adjustedTime;
-    }
-
-    @Deprecated // 프론트 마이그레이션 완료 후 제거 예정
-    private CycleSelection resolveDefaultCycleIfNull(final CycleSelection cycleSelection) {
-        if (cycleSelection != null) {
-            return cycleSelection;
-        }
-        return new DefaultCycleSelection("EBBINGHAUS");
     }
 
     private void savePendingNotificationHistory(final List<ReviewCycle> savedReviewCycles) {

--- a/src/test/java/com/recyclestudy/cycle/service/resolver/CycleSelectionResolverRegistryTest.java
+++ b/src/test/java/com/recyclestudy/cycle/service/resolver/CycleSelectionResolverRegistryTest.java
@@ -1,7 +1,6 @@
 package com.recyclestudy.cycle.service.resolver;
 
 import com.recyclestudy.cycle.domain.DefaultCycleOption;
-import com.recyclestudy.cycle.domain.selection.CustomCycleSelection;
 import com.recyclestudy.cycle.domain.selection.CycleSelection;
 import com.recyclestudy.cycle.domain.selection.DefaultCycleSelection;
 import com.recyclestudy.cycle.repository.CycleOptionRepository;

--- a/src/test/java/com/recyclestudy/email/ReviewEmailSenderTest.java
+++ b/src/test/java/com/recyclestudy/email/ReviewEmailSenderTest.java
@@ -6,7 +6,6 @@ import com.recyclestudy.review.service.ReviewCycleService;
 import com.recyclestudy.review.service.output.ReviewSendOutput;
 import com.recyclestudy.review.service.output.ReviewSendOutput.ReviewSendElement;
 import java.time.Clock;
-import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.List;
@@ -18,7 +17,6 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.jupiter.api.Assertions.assertTimeout;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;

--- a/src/test/java/com/recyclestudy/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/recyclestudy/member/controller/MemberControllerTest.java
@@ -491,7 +491,8 @@ class MemberControllerTest extends APIBaseTest {
                                         headerWithName("X-Device-Id").description("디바이스 식별자")
                                 )
                                 .requestFields(
-                                        fieldWithPath("notificationTime").type(JsonFieldType.STRING).description("알림 시간 (HH:mm:ss)")
+                                        fieldWithPath("notificationTime").type(JsonFieldType.STRING)
+                                                .description("알림 시간 (HH:mm:ss)")
                                 )
                 ))
                 .contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/src/test/java/com/recyclestudy/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/recyclestudy/review/controller/ReviewControllerTest.java
@@ -55,51 +55,6 @@ class ReviewControllerTest extends APIBaseTest {
     }
 
     @Test
-    @DisplayName("cycle 없이 리뷰를 저장하면 기본 주기로 201 응답을 반환한다 (하위 호환)")
-    void saveReview_withoutCycle_backwardCompatible() {
-        // given
-        final String identifier = "device-id";
-        final String url = "https://test.com";
-        final ReviewSaveRequest request = new ReviewSaveRequest(url, null);
-        final ReviewSaveOutput output = ReviewSaveOutput.of(ReviewURL.from(url),
-                List.of(LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES)));
-
-        given(reviewService.saveReview(any())).willReturn(output);
-
-        // when
-        // then
-        given(this.spec)
-                .filter(document(DEFAULT_REST_DOC_PATH,
-                        builder()
-                                .tag("Review")
-                                .summary("리뷰 저장 (하위 호환)")
-                                .description("cycle 없이 리뷰를 저장하면 기본 주기(EBBINGHAUS)로 저장된다")
-                                .requestHeaders(
-                                        headerWithName("X-Device-Id").description("디바이스 식별자")
-                                )
-                                .requestFields(
-                                        fieldWithPath("targetUrl").type(JsonFieldType.STRING)
-                                                .description("리뷰할 URL"),
-                                        fieldWithPath("cycle").type(JsonFieldType.NULL)
-                                                .description("복습 주기 선택 (null이면 기본 주기 사용)").optional()
-                                )
-                                .responseFields(
-                                        fieldWithPath("url").type(JsonFieldType.STRING).description("리뷰할 URL"),
-                                        fieldWithPath("scheduledAts").type(JsonFieldType.ARRAY)
-                                                .description("복습 예정 일시 목록")
-                                )
-                ))
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header("X-Device-Id", identifier)
-                .body(request)
-                .when()
-                .post("/api/v1/reviews")
-                .then()
-                .statusCode(HttpStatus.CREATED.value())
-                .body("url", equalTo(url));
-    }
-
-    @Test
     @DisplayName("기본 주기로 리뷰를 저장하면 201 응답을 반환한다")
     void saveReview_withDefaultCycle() {
         // given

--- a/src/test/java/com/recyclestudy/review/service/NotificationHistoryServiceTest.java
+++ b/src/test/java/com/recyclestudy/review/service/NotificationHistoryServiceTest.java
@@ -46,7 +46,7 @@ class NotificationHistoryServiceTest {
 
         final Member member = Member.withoutId(Email.from("test@test.com"));
         final Review review = Review.withoutId(member, ReviewURL.from("https://test.com"));
-        
+
         final LocalDateTime now = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES);
         final ReviewCycle cycle1 = ReviewCycle.withoutId(review, now);
         final ReviewCycle cycle2 = ReviewCycle.withoutId(review, now.plusDays(1));

--- a/src/test/java/com/recyclestudy/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/recyclestudy/review/service/ReviewServiceTest.java
@@ -115,39 +115,6 @@ class ReviewServiceTest {
     }
 
     @Test
-    @DisplayName("cycle이 null이면 기본 주기(EBBINGHAUS)를 사용한다")
-    void saveReview_withNullCycle_usesDefaultCycle() {
-        // given
-        final DeviceIdentifier identifier = DeviceIdentifier.from("device-id");
-        final String urlValue = "https://test.com";
-        final ReviewSaveInput input = ReviewSaveInput.of(identifier, urlValue, null);
-
-        final Email email = Email.from("test@test.com");
-        final Member member = Member.withoutId(email);
-        final Review review = Review.withoutId(member, ReviewURL.from(urlValue));
-        final ReviewCycle cycle = ReviewCycle.withoutId(review, now.plusDays(1));
-
-        final List<Duration> durations = List.of(Duration.ofDays(1));
-        final DefaultCycleSelection defaultCycle = new DefaultCycleSelection("EBBINGHAUS");
-
-        given(memberRepository.findByIdentifier(any(DeviceIdentifier.class))).willReturn(Optional.of(member));
-        given(cycleSelectionResolverRegistry.resolve(defaultCycle)).willReturn(durations);
-        given(reviewRepository.save(any(Review.class))).willReturn(review);
-        given(reviewCycleRepository.saveAll(anyList())).willReturn(List.of(cycle));
-
-        // when
-        final ReviewSaveOutput actual = reviewService.saveReview(input);
-
-        // then
-        assertSoftly(softAssertions -> {
-            softAssertions.assertThat(actual.url()).isEqualTo(ReviewURL.from(urlValue));
-            softAssertions.assertThat(actual.scheduledAts()).hasSize(1);
-        });
-
-        verify(cycleSelectionResolverRegistry).resolve(defaultCycle);
-    }
-
-    @Test
     @DisplayName("존재하지 않는 디바이스 아이디일 경우 예외를 던진다")
     void saveReview_fail_notFoundDevice() {
         // given


### PR DESCRIPTION
<!-- PR 템플릿 -->

## 🚀 작업 내용

프런트엔드 마이그레이션 완료에 따라 null 입력 시 기본 주기로 변환하는 로직 제거

## 📸 이슈 번호

- close #60 

## ✍ 궁금한 점

- X
