### PR TITLE
멤버 알림 시간 조회 API 추가

### DIFF
--- a/src/main/java/com/recyclestudy/member/controller/MemberController.java
+++ b/src/main/java/com/recyclestudy/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.recyclestudy.email.DeviceAuthEmailSender;
 import com.recyclestudy.member.controller.request.MemberNotificationTimeUpdateRequest;
 import com.recyclestudy.member.controller.request.MemberSaveRequest;
 import com.recyclestudy.member.controller.response.MemberFindResponse;
+import com.recyclestudy.member.controller.response.MemberNotificationTimeFindResponse;
 import com.recyclestudy.member.controller.response.MemberSaveResponse;
 import com.recyclestudy.member.domain.DeviceIdentifier;
 import com.recyclestudy.member.service.MemberService;
@@ -12,6 +13,7 @@ import com.recyclestudy.member.service.input.MemberFindInput;
 import com.recyclestudy.member.service.input.MemberNotificationTimeUpdateInput;
 import com.recyclestudy.member.service.input.MemberSaveInput;
 import com.recyclestudy.member.service.output.MemberFindOutput;
+import com.recyclestudy.member.service.output.MemberNotificationTimeFindOutput;
 import com.recyclestudy.member.service.output.MemberSaveOutput;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -52,6 +54,15 @@ public class MemberController {
         final MemberFindInput input = MemberFindInput.from(email, identifier);
         final MemberFindOutput output = memberService.findAllMemberDevices(input);
         final MemberFindResponse response = MemberFindResponse.from(output);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/notification-time")
+    public ResponseEntity<MemberNotificationTimeFindResponse> findNotificationTime(
+            @AuthDevice final DeviceIdentifier identifier
+    ) {
+        final MemberNotificationTimeFindOutput output = memberService.findNotificationTime(identifier);
+        final MemberNotificationTimeFindResponse response = MemberNotificationTimeFindResponse.from(output);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/recyclestudy/member/controller/response/MemberFindResponse.java
+++ b/src/main/java/com/recyclestudy/member/controller/response/MemberFindResponse.java
@@ -2,17 +2,16 @@ package com.recyclestudy.member.controller.response;
 
 import com.recyclestudy.member.service.output.MemberFindOutput;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.List;
 
-public record MemberFindResponse(String email, LocalTime notificationTime, List<MemberFindElement> devices) {
+public record MemberFindResponse(String email, List<MemberFindElement> devices) {
 
     public static MemberFindResponse from(final MemberFindOutput output) {
         final List<MemberFindElement> memberFindElements = output.elements().stream()
                 .map(outputElement -> new MemberFindElement(outputElement.identifier().getValue(),
                         outputElement.createdAt()))
                 .toList();
-        return new MemberFindResponse(output.email().getValue(), output.notificationTime(), memberFindElements);
+        return new MemberFindResponse(output.email().getValue(), memberFindElements);
     }
 
     private record MemberFindElement(String identifier, LocalDateTime createdAt) {

--- a/src/main/java/com/recyclestudy/member/controller/response/MemberNotificationTimeFindResponse.java
+++ b/src/main/java/com/recyclestudy/member/controller/response/MemberNotificationTimeFindResponse.java
@@ -1,0 +1,10 @@
+package com.recyclestudy.member.controller.response;
+
+import com.recyclestudy.member.service.output.MemberNotificationTimeFindOutput;
+import java.time.LocalTime;
+
+public record MemberNotificationTimeFindResponse(LocalTime notificationTime) {
+    public static MemberNotificationTimeFindResponse from(final MemberNotificationTimeFindOutput output) {
+        return new MemberNotificationTimeFindResponse(output.notificationTime());
+    }
+}

--- a/src/main/java/com/recyclestudy/member/service/MemberService.java
+++ b/src/main/java/com/recyclestudy/member/service/MemberService.java
@@ -15,6 +15,7 @@ import com.recyclestudy.member.service.input.MemberFindInput;
 import com.recyclestudy.member.service.input.MemberNotificationTimeUpdateInput;
 import com.recyclestudy.member.service.input.MemberSaveInput;
 import com.recyclestudy.member.service.output.MemberFindOutput;
+import com.recyclestudy.member.service.output.MemberNotificationTimeFindOutput;
 import com.recyclestudy.member.service.output.MemberSaveOutput;
 import java.time.Clock;
 import java.time.LocalDateTime;
@@ -23,7 +24,6 @@ import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -54,18 +54,14 @@ public class MemberService {
     @Transactional(readOnly = true)
     public MemberFindOutput findAllMemberDevices(final MemberFindInput input) {
         final List<Device> devices = deviceRepository.findAllByMemberEmail(input.email());
-        final LocalTime notificationTime = findNotificationTime(input.email(), devices);
-        return MemberFindOutput.of(input.email(), notificationTime, devices);
+        return MemberFindOutput.of(input.email(), devices);
     }
 
-    @Nullable
-    private LocalTime findNotificationTime(final Email email, final List<Device> devices) {
-        if (devices.isEmpty()) {
-            return memberRepository.findByEmail(email)
-                    .map(Member::getNotificationTime)
-                    .orElse(null);
-        }
-        return devices.getFirst().getMember().getNotificationTime();
+    @Transactional(readOnly = true)
+    public MemberNotificationTimeFindOutput findNotificationTime(final DeviceIdentifier identifier) {
+        final Member member = memberRepository.findByIdentifier(identifier)
+                .orElseThrow(() -> new UnauthorizedException("유효하지 않은 디바이스입니다"));
+        return MemberNotificationTimeFindOutput.from(member.getNotificationTime());
     }
 
     @Transactional

--- a/src/main/java/com/recyclestudy/member/service/output/MemberFindOutput.java
+++ b/src/main/java/com/recyclestudy/member/service/output/MemberFindOutput.java
@@ -4,20 +4,18 @@ import com.recyclestudy.member.domain.Device;
 import com.recyclestudy.member.domain.DeviceIdentifier;
 import com.recyclestudy.member.domain.Email;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.List;
 
-public record MemberFindOutput(Email email, LocalTime notificationTime, List<MemberFindElement> elements) {
+public record MemberFindOutput(Email email, List<MemberFindElement> elements) {
 
     public static MemberFindOutput of(
             final Email email,
-            final LocalTime notificationTime,
             final List<Device> devices
     ) {
         final List<MemberFindElement> memberFindElements = devices.stream()
                 .map(device -> new MemberFindElement(device.getIdentifier(), device.getCreatedAt()))
                 .toList();
-        return new MemberFindOutput(email, notificationTime, memberFindElements);
+        return new MemberFindOutput(email, memberFindElements);
     }
 
     public record MemberFindElement(DeviceIdentifier identifier, LocalDateTime createdAt) {

--- a/src/main/java/com/recyclestudy/member/service/output/MemberNotificationTimeFindOutput.java
+++ b/src/main/java/com/recyclestudy/member/service/output/MemberNotificationTimeFindOutput.java
@@ -1,0 +1,9 @@
+package com.recyclestudy.member.service.output;
+
+import java.time.LocalTime;
+
+public record MemberNotificationTimeFindOutput(LocalTime notificationTime) {
+    public static MemberNotificationTimeFindOutput from(final LocalTime notificationTime) {
+        return new MemberNotificationTimeFindOutput(notificationTime);
+    }
+}

--- a/src/test/java/com/recyclestudy/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/recyclestudy/member/controller/MemberControllerTest.java
@@ -14,6 +14,7 @@ import com.recyclestudy.member.repository.DeviceRepository;
 import com.recyclestudy.member.service.MemberService;
 import com.recyclestudy.member.service.input.MemberNotificationTimeUpdateInput;
 import com.recyclestudy.member.service.output.MemberFindOutput;
+import com.recyclestudy.member.service.output.MemberNotificationTimeFindOutput;
 import com.recyclestudy.member.service.output.MemberSaveOutput;
 import com.recyclestudy.restdocs.APIBaseTest;
 import java.time.LocalDateTime;
@@ -21,6 +22,7 @@ import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -121,7 +123,6 @@ class MemberControllerTest extends APIBaseTest {
 
         final MemberFindOutput output = new MemberFindOutput(
                 Email.from(email),
-                LocalTime.of(9, 0),
                 List.of(device1, device2)
         );
 
@@ -143,8 +144,6 @@ class MemberControllerTest extends APIBaseTest {
                                 )
                                 .responseFields(
                                         fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
-                                        fieldWithPath("notificationTime").type(JsonFieldType.STRING)
-                                                .description("알림 시간").optional(),
                                         fieldWithPath("devices").type(JsonFieldType.ARRAY).description("디바이스 목록"),
                                         fieldWithPath("devices[].identifier").type(JsonFieldType.STRING)
                                                 .description("디바이스 식별자 값"),
@@ -428,7 +427,6 @@ class MemberControllerTest extends APIBaseTest {
 
         final MemberFindOutput output = new MemberFindOutput(
                 Email.from(email),
-                null,
                 List.of(device1, device2)
         );
 
@@ -450,8 +448,6 @@ class MemberControllerTest extends APIBaseTest {
                                 )
                                 .responseFields(
                                         fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
-                                        fieldWithPath("notificationTime").type(JsonFieldType.STRING)
-                                                .description("알림 시간").optional(),
                                         fieldWithPath("devices").type(JsonFieldType.ARRAY).description("디바이스 목록"),
                                         fieldWithPath("devices[].identifier").type(JsonFieldType.STRING)
                                                 .description("디바이스 식별자 값"),
@@ -469,6 +465,105 @@ class MemberControllerTest extends APIBaseTest {
                 .then()
                 .statusCode(HttpStatus.OK.value())
                 .body("devices", hasSize(2));
+    }
+
+    @Test
+    @DisplayName("멤버의 알림 시간을 조회한다")
+    void findNotificationTime() {
+        // given
+        final String headerIdentifier = "device-id-1";
+        final LocalTime notificationTime = LocalTime.of(9, 0);
+        final MemberNotificationTimeFindOutput output = new MemberNotificationTimeFindOutput(notificationTime);
+
+        given(memberService.findNotificationTime(any(DeviceIdentifier.class))).willReturn(output);
+
+        // when
+        // then
+        given(this.spec)
+                .filter(document(DEFAULT_REST_DOC_PATH,
+                        builder()
+                                .tag("Member")
+                                .summary("멤버 알림 시간 조회")
+                                .description("멤버의 알림 시간을 조회한다")
+                                .requestHeaders(
+                                        headerWithName("X-Device-Id").description("디바이스 식별자")
+                                )
+                                .responseFields(
+                                        fieldWithPath("notificationTime").type(JsonFieldType.STRING)
+                                                .description("알림 시간 (HH:mm:ss)")
+                                )
+                ))
+                .header("X-Device-Id", headerIdentifier)
+                .when()
+                .get("/api/v1/members/notification-time")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .body("notificationTime", equalTo("09:00:00"));
+    }
+
+    @Test
+    @DisplayName("알림 시간을 설정하지 않은 멤버 조회 시 null을 반환한다")
+    void findNotificationTime_NullNotificationTime() {
+        // given
+        final String headerIdentifier = "device-id-1";
+        final MemberNotificationTimeFindOutput output = new MemberNotificationTimeFindOutput(null);
+
+        given(memberService.findNotificationTime(any(DeviceIdentifier.class))).willReturn(output);
+
+        // when
+        // then
+        given(this.spec)
+                .filter(document(DEFAULT_REST_DOC_PATH,
+                        builder()
+                                .tag("Member")
+                                .summary("멤버 알림 시간 조회")
+                                .description("알림 시간을 설정하지 않은 멤버 조회 시 null을 반환한다")
+                                .requestHeaders(
+                                        headerWithName("X-Device-Id").description("디바이스 식별자")
+                                )
+                                .responseFields(
+                                        fieldWithPath("notificationTime").type(JsonFieldType.STRING)
+                                                .description("알림 시간 (미설정 시 null)").optional()
+                                )
+                ))
+                .header("X-Device-Id", headerIdentifier)
+                .when()
+                .get("/api/v1/members/notification-time")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .body("notificationTime", Matchers.nullValue());
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 디바이스로 알림 시간 조회 시 401 응답을 반환한다")
+    void findNotificationTime_UnauthorizedDevice() {
+        // given
+        final String headerIdentifier = "invalid-device-id";
+
+        given(memberService.findNotificationTime(any(DeviceIdentifier.class)))
+                .willThrow(new UnauthorizedException("유효하지 않은 디바이스입니다"));
+
+        // when
+        // then
+        given(this.spec)
+                .filter(document(DEFAULT_REST_DOC_PATH,
+                        builder()
+                                .tag("Member")
+                                .summary("멤버 알림 시간 조회")
+                                .description("유효하지 않은 디바이스로 알림 시간 조회 시 401 응답을 반환한다")
+                                .requestHeaders(
+                                        headerWithName("X-Device-Id").description("디바이스 식별자")
+                                )
+                                .responseFields(
+                                        fieldWithPath("message").type(JsonFieldType.STRING).description("에러 메시지")
+                                )
+                ))
+                .header("X-Device-Id", headerIdentifier)
+                .when()
+                .get("/api/v1/members/notification-time")
+                .then()
+                .statusCode(HttpStatus.UNAUTHORIZED.value())
+                .body("message", equalTo("유효하지 않은 디바이스입니다"));
     }
 
     @Test

--- a/src/test/java/com/recyclestudy/member/service/MemberServiceTest.java
+++ b/src/test/java/com/recyclestudy/member/service/MemberServiceTest.java
@@ -15,6 +15,7 @@ import com.recyclestudy.member.service.input.MemberFindInput;
 import com.recyclestudy.member.service.input.MemberNotificationTimeUpdateInput;
 import com.recyclestudy.member.service.input.MemberSaveInput;
 import com.recyclestudy.member.service.output.MemberFindOutput;
+import com.recyclestudy.member.service.output.MemberNotificationTimeFindOutput;
 import com.recyclestudy.member.service.output.MemberSaveOutput;
 import java.time.Clock;
 import java.time.Instant;
@@ -239,6 +240,55 @@ class MemberServiceTest {
 
         // then
         verify(deviceRepository).deleteByIdentifier(targetDeviceIdentifier);
+    }
+
+    @Test
+    @DisplayName("디바이스 식별자로 멤버의 알림 시간을 조회한다")
+    void findNotificationTime() {
+        // given
+        final DeviceIdentifier identifier = DeviceIdentifier.from("device-id");
+        final Member member = Member.withoutId(Email.from("test@test.com"));
+        final LocalTime expectedTime = LocalTime.of(9, 0);
+        member.updateNotificationTime(expectedTime);
+
+        given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.of(member));
+
+        // when
+        final MemberNotificationTimeFindOutput actual = memberService.findNotificationTime(identifier);
+
+        // then
+        assertThat(actual.notificationTime()).isEqualTo(expectedTime);
+    }
+
+    @Test
+    @DisplayName("알림 시간을 설정하지 않은 멤버 조회 시 null을 반환한다")
+    void findNotificationTime_NullNotificationTime() {
+        // given
+        final DeviceIdentifier identifier = DeviceIdentifier.from("device-id");
+        final Member member = Member.withoutId(Email.from("test@test.com"));
+
+        given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.of(member));
+
+        // when
+        final MemberNotificationTimeFindOutput actual = memberService.findNotificationTime(identifier);
+
+        // then
+        assertThat(actual.notificationTime()).isNull();
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 디바이스로 알림 시간 조회 시 예외를 던진다")
+    void findNotificationTime_UnauthorizedDevice() {
+        // given
+        final DeviceIdentifier identifier = DeviceIdentifier.from("invalid-id");
+
+        given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.empty());
+
+        // when
+        // then
+        assertThatThrownBy(() -> memberService.findNotificationTime(identifier))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasMessage("유효하지 않은 디바이스입니다");
     }
 
     @Test


### PR DESCRIPTION
<!-- PR 템플릿 -->

## 🚀 작업 내용

- `GET /api/v1/members/notification-time` 알림 시간 조회 API 추가
- `MemberNotificationTimeFindResponse`, `MemberNotificationTimeFindOutput` 신규 생성
- `MemberService.findNotificationTime()` 구현
  - `Optional.map` 대신 `Member` 객체를 먼저 조회하여 알림 시간 미설정(null) 멤버도 정상 응답하도록 처리
- `MemberFindOutput`, `MemberFindResponse`에서 `notificationTime` 필드 제거 (책임 분리)

## 📸 이슈 번호

- close #62 

## ✍ 궁금한 점

- X
