### PR TITLE
로그 패턴에 스레드 정보 추가

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -6,7 +6,7 @@
     <property name="CONSOLE_LOG_PATTERN"
               value="%d{yyyy-MM-dd HH:mm:ss.SSS} %highlight(%-5level) [%blue(%X{traceId:-NO_TRACE_ID})] [%thread] %magenta(%-40.40logger{39}) : %msg%n"/>
     <property name="FILE_LOG_PATTERN"
-              value="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%X{traceId:-}] %-40.40logger{39} : %msg%n"/>
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%X{traceId:-}] [%thread] %-40.40logger{39} : %msg%n"/>
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -4,7 +4,7 @@
 
     <property name="LOG_PATH" value="/app/log"/>
     <property name="CONSOLE_LOG_PATTERN"
-              value="%d{yyyy-MM-dd HH:mm:ss.SSS} %highlight(%-5level) [%blue(%X{traceId:-NO_TRACE_ID})] %magenta(%-40.40logger{39}) : %msg%n"/>
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} %highlight(%-5level) [%blue(%X{traceId:-NO_TRACE_ID})] [%thread] %magenta(%-40.40logger{39}) : %msg%n"/>
     <property name="FILE_LOG_PATTERN"
               value="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%X{traceId:-}] %-40.40logger{39} : %msg%n"/>
 


### PR DESCRIPTION
<!-- PR 템플릿 -->

## 🚀 작업 내용

- 콘솔 로그 패턴(`CONSOLE_LOG_PATTERN`)에 `[%thread]` 항목을 추가하여 로그 출력 시 스레드 이름이 함께 표시되도록 변경
- 변경 전: `%d{...} %-5level [%X{traceId:-NO_TRACE_ID}] %-40.40logger{39} : %msg%n`
- 변경 후: `%d{...} %-5level [%X{traceId:-NO_TRACE_ID}] [%thread] %-40.40logger{39} : %msg%n`
- 멀티 스레드 환경에서 로그 추적 시 어떤 스레드에서 발생한 로그인지 식별할 수 있도록 개선

## 📸 이슈 번호

- close #64 

## ✍ 궁금한 점

- X