### PR TITLE
커스텀 복습 주기 소유권 검증 누락 수정

### DIFF
--- a/src/main/java/com/recyclestudy/review/service/ReviewService.java
+++ b/src/main/java/com/recyclestudy/review/service/ReviewService.java
@@ -1,8 +1,12 @@
 package com.recyclestudy.review.service;
 
 import com.recyclestudy.common.BaseEntity;
+import com.recyclestudy.cycle.domain.CycleOption;
+import com.recyclestudy.cycle.domain.selection.CustomCycleSelection;
 import com.recyclestudy.cycle.domain.selection.CycleSelection;
+import com.recyclestudy.cycle.repository.CycleOptionRepository;
 import com.recyclestudy.cycle.service.resolver.CycleSelectionResolverRegistry;
+import com.recyclestudy.exception.NotFoundException;
 import com.recyclestudy.exception.UnauthorizedException;
 import com.recyclestudy.member.domain.Member;
 import com.recyclestudy.member.repository.MemberRepository;
@@ -33,6 +37,7 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final ReviewCycleRepository reviewCycleRepository;
     private final MemberRepository memberRepository;
+    private final CycleOptionRepository cycleOptionRepository;
     private final CycleSelectionResolverRegistry cycleSelectionResolverRegistry;
     private final NotificationHistoryRepository notificationHistoryRepository;
     private final Clock clock;
@@ -46,6 +51,7 @@ public class ReviewService {
         final Review savedReview = reviewRepository.save(review);
         log.info("[REVIEW_SAVED] 복습 주제 저장 성공: reviewId={}", savedReview.getId());
 
+        validateCycleSelectionOwnership(input.cycle(), member);
         final List<LocalDateTime> scheduledAts = calculateScheduledAts(input.cycle(), member);
 
         final List<ReviewCycle> reviewCycles = scheduledAts.stream()
@@ -97,5 +103,18 @@ public class ReviewService {
                 = notificationHistoryRepository.saveAll(notificationHistories);
         log.info("[NOTIFY_HIST_SAVED] 전송 현황 등록 성공: status={}, notificationHistoryId={}",
                 NotificationStatus.PENDING, savedNotificationHistories.stream().map(BaseEntity::getId).toList());
+    }
+
+    private void validateCycleSelectionOwnership(final CycleSelection cycleSelection, final Member member) {
+        if (!(cycleSelection instanceof CustomCycleSelection(Long id))) {
+            return;
+        }
+
+        final CycleOption cycleOption = cycleOptionRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 복습 주기입니다"));
+
+        if (!cycleOption.isOwner(member)) {
+            throw new NotFoundException("존재하지 않는 복습 주기입니다");
+        }
     }
 }

--- a/src/test/java/com/recyclestudy/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/recyclestudy/review/service/ReviewServiceTest.java
@@ -1,7 +1,11 @@
 package com.recyclestudy.review.service;
 
+import com.recyclestudy.cycle.domain.CycleOption;
+import com.recyclestudy.cycle.domain.selection.CustomCycleSelection;
 import com.recyclestudy.cycle.domain.selection.DefaultCycleSelection;
+import com.recyclestudy.cycle.repository.CycleOptionRepository;
 import com.recyclestudy.cycle.service.resolver.CycleSelectionResolverRegistry;
+import com.recyclestudy.exception.NotFoundException;
 import com.recyclestudy.exception.UnauthorizedException;
 import com.recyclestudy.member.domain.DeviceIdentifier;
 import com.recyclestudy.member.domain.Email;
@@ -41,6 +45,7 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -54,6 +59,9 @@ class ReviewServiceTest {
 
     @Mock
     MemberRepository memberRepository;
+
+    @Mock
+    CycleOptionRepository cycleOptionRepository;
 
     @Mock
     CycleSelectionResolverRegistry cycleSelectionResolverRegistry;
@@ -170,5 +178,82 @@ class ReviewServiceTest {
             softAssertions.assertThat(capturedCycles.get(1).getScheduledAt())
                     .isEqualTo(now.plusDays(1).with(preferredTime));
         });
+    }
+
+    @Test
+    @DisplayName("사용자가 소유한 커스텀 주기로 리뷰를 저장한다")
+    void saveReview_withCustomCycle_owner() {
+        // given
+        final long cycleOptionId = 1L;
+        final DeviceIdentifier identifier = DeviceIdentifier.from("device-id");
+        final CustomCycleSelection cycleSelection = new CustomCycleSelection(cycleOptionId);
+        final ReviewSaveInput input = ReviewSaveInput.of(identifier, "https://test.com", cycleSelection);
+
+        final Member member = Member.withoutId(Email.from("test@test.com"));
+        final Review review = Review.withoutId(member, input.url());
+        final ReviewCycle cycle = ReviewCycle.withoutId(review, now.plusDays(1));
+        final CycleOption cycleOption = mock(CycleOption.class);
+        final List<Duration> durations = List.of(Duration.ofDays(1));
+
+        given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.of(member));
+        given(reviewRepository.save(any(Review.class))).willReturn(review);
+        given(cycleOptionRepository.findById(cycleOptionId)).willReturn(Optional.of(cycleOption));
+        given(cycleOption.isOwner(member)).willReturn(true);
+        given(cycleSelectionResolverRegistry.resolve(cycleSelection)).willReturn(durations);
+        given(reviewCycleRepository.saveAll(anyList())).willReturn(List.of(cycle));
+
+        // when
+        reviewService.saveReview(input);
+
+        // then
+        verify(cycleOptionRepository).findById(cycleOptionId);
+        verify(cycleOption).isOwner(member);
+        verify(cycleSelectionResolverRegistry).resolve(cycleSelection);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 커스텀 주기일 경우 예외를 던진다")
+    void saveReview_withCustomCycle_notFoundCycleOption() {
+        // given
+        final long cycleOptionId = 999L;
+        final DeviceIdentifier identifier = DeviceIdentifier.from("device-id");
+        final CustomCycleSelection cycleSelection = new CustomCycleSelection(cycleOptionId);
+        final ReviewSaveInput input = ReviewSaveInput.of(identifier, "https://test.com", cycleSelection);
+
+        final Member member = Member.withoutId(Email.from("test@test.com"));
+        final Review review = Review.withoutId(member, input.url());
+
+        given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.of(member));
+        given(reviewRepository.save(any(Review.class))).willReturn(review);
+        given(cycleOptionRepository.findById(cycleOptionId)).willReturn(Optional.empty());
+
+        // when
+        // then
+        assertThatThrownBy(() -> reviewService.saveReview(input))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("본인이 소유하지 않은 커스텀 주기일 경우 예외를 던진다")
+    void saveReview_withCustomCycle_notOwner() {
+        // given
+        final long cycleOptionId = 10L;
+        final DeviceIdentifier identifier = DeviceIdentifier.from("device-id");
+        final CustomCycleSelection cycleSelection = new CustomCycleSelection(cycleOptionId);
+        final ReviewSaveInput input = ReviewSaveInput.of(identifier, "https://test.com", cycleSelection);
+
+        final Member member = Member.withoutId(Email.from("test@test.com"));
+        final Review review = Review.withoutId(member, input.url());
+        final CycleOption cycleOption = mock(CycleOption.class);
+
+        given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.of(member));
+        given(reviewRepository.save(any(Review.class))).willReturn(review);
+        given(cycleOptionRepository.findById(cycleOptionId)).willReturn(Optional.of(cycleOption));
+        given(cycleOption.isOwner(member)).willReturn(false);
+
+        // when
+        // then
+        assertThatThrownBy(() -> reviewService.saveReview(input))
+                .isInstanceOf(NotFoundException.class);
     }
 }


### PR DESCRIPTION
<!-- PR 템플릿 -->

## 🚀 작업 내용

- `ReviewService`에 커스텀 복습 주기 소유권 검증 로직을 추가
- `cycle`이 `CustomCycleSelection`인 경우에만 주기 소유권 검증 수행
- 커스텀 주기 조회를 위해 `CycleOptionRepository` 의존성 추가
- 커스텀 주기가 존재하지 않거나 요청자 소유가 아니면 `NotFoundException` 반환
- 검증 통과 시 기존 복습 스케줄 계산/저장 흐름 유지

## 📸 이슈 번호

- close #70 

## ✍ 궁금한 점

- X
