### PR TITLE
Virtual Thread 적용을 통한 이메일 발송 처리량 개선

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:25-alpine
+FROM amazoncorretto:25-alpine3.21
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:21-alpine3.19
+FROM amazoncorretto:25-alpine
 
 WORKDIR /app
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,10 @@
 spring:
   application:
     name: recyclestudy
+
+  threads:
+    virtual:
+      enabled: true
   profiles:
     active: local
 


### PR DESCRIPTION
<!-- PR 템플릿 -->

## 🚀 작업 내용

Jakarta Mail `SMTPTransport.sendMessage()`의 `synchronized` + Socket I/O 구조로 인한 Virtual Thread pinning 문제를 분석하고, JEP 491이 적용된 Java 25 런타임으로 Docker 이미지를 교체하여 VT를 활성화.

### **변경 사항**

| 파일 | 변경 내용 |
|---|---|
| `Dockerfile` | `amazoncorretto:21-alpine3.19` → `amazoncorretto:25-alpine` |
| `application.yaml` | `spring.threads.virtual.enabled=true` 추가 |

### **컴파일 환경을 Java 21로 유지한 이유**

Gradle 8.14.3의 Groovy 컴파일러(3.0.24)가 Java 25 class file format(major version 69)을 지원하지 않아 `build.gradle` 컴파일 단계에서 실패함을 확인. JEP 491은 JVM 런타임 레벨의 변경이므로 런타임만 Java 25로 교체하는 것으로 충분하다고 판단.

## 📸 이슈 번호

- close #74 

## ✍ 궁금한 점
- X