### PR TITLE
이메일 발송 로직 notification_history outbox 패턴 전환

### DIFF
--- a/src/main/java/com/recyclestudy/email/EmailRetryService.java
+++ b/src/main/java/com/recyclestudy/email/EmailRetryService.java
@@ -21,6 +21,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class EmailRetryService {
 
+    // 단기 주기(1일 미만) 재시도 제외: review_cycle에 주기 컬럼이 없으므로 scheduledAt 경과 시간으로 단기/장기 여부를 역산
+    private static final long SHORT_CYCLE_THRESHOLD_DAYS = 1;
     private static final int MAX_RETRY_COUNT = 3;
 
     private final ReviewCycleRepository reviewCycleRepository;
@@ -29,7 +31,7 @@ public class EmailRetryService {
 
     @Transactional(readOnly = true)
     public void retryFailedEmails() {
-        final LocalDateTime cutoffDateTime = LocalDateTime.now(clock).minusDays(1);
+        final LocalDateTime cutoffDateTime = LocalDateTime.now(clock).minusDays(SHORT_CYCLE_THRESHOLD_DAYS);
         final List<ReviewCycle> failedCycles = reviewCycleRepository.findAllRetryableCycles(
                 NotificationStatus.FAILED, MAX_RETRY_COUNT, cutoffDateTime);
 

--- a/src/main/java/com/recyclestudy/email/EmailRetryService.java
+++ b/src/main/java/com/recyclestudy/email/EmailRetryService.java
@@ -1,10 +1,13 @@
 package com.recyclestudy.email;
 
 import com.recyclestudy.member.domain.Member;
+import com.recyclestudy.review.domain.NotificationStatus;
 import com.recyclestudy.review.domain.ReviewCycle;
 import com.recyclestudy.review.domain.ReviewURL;
 import com.recyclestudy.review.repository.ReviewCycleRepository;
 import com.recyclestudy.review.service.output.ReviewSendOutput.ReviewSendElement;
+import java.time.Clock;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -22,10 +25,13 @@ public class EmailRetryService {
 
     private final ReviewCycleRepository reviewCycleRepository;
     private final SingleReviewEmailSender singleReviewEmailSender;
+    private final Clock clock;
 
     @Transactional(readOnly = true)
     public void retryFailedEmails() {
-        final List<ReviewCycle> failedCycles = reviewCycleRepository.findAllRetryableCycles(MAX_RETRY_COUNT);
+        final LocalDateTime cutoffDateTime = LocalDateTime.now(clock).minusDays(1);
+        final List<ReviewCycle> failedCycles = reviewCycleRepository.findAllRetryableCycles(
+                NotificationStatus.FAILED, MAX_RETRY_COUNT, cutoffDateTime);
 
         if (failedCycles.isEmpty()) {
             return;

--- a/src/main/java/com/recyclestudy/email/SingleReviewEmailSender.java
+++ b/src/main/java/com/recyclestudy/email/SingleReviewEmailSender.java
@@ -30,10 +30,10 @@ public class SingleReviewEmailSender {
         final boolean success = sendToTargetEmail(targetEmail, message);
 
         if (success) {
-            notificationHistoryService.saveAll(element.reviewCycleIds(), NotificationStatus.SENT);
+            notificationHistoryService.updateStatus(element.reviewCycleIds(), NotificationStatus.SENT);
             return;
         }
-        notificationHistoryService.saveAll(element.reviewCycleIds(), NotificationStatus.FAILED);
+        notificationHistoryService.updateStatus(element.reviewCycleIds(), NotificationStatus.FAILED);
     }
 
     private boolean sendToTargetEmail(final Email targetEmail, final String message) {

--- a/src/main/java/com/recyclestudy/review/domain/NotificationHistory.java
+++ b/src/main/java/com/recyclestudy/review/domain/NotificationHistory.java
@@ -10,6 +10,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -32,12 +33,18 @@ public class NotificationHistory extends BaseEntity {
     @Column(name = "status", nullable = false)
     private NotificationStatus status;
 
+    @Column(name = "fail_count", nullable = false)
+    private int failCount;
+
+    @Column(name = "last_attempted_at")
+    private LocalDateTime lastAttemptedAt;
+
     public static NotificationHistory withoutId(
             final ReviewCycle reviewCycle,
             final NotificationStatus status
     ) {
         validateNotNull(reviewCycle, status);
-        return new NotificationHistory(reviewCycle, status);
+        return new NotificationHistory(reviewCycle, status, 0, null);
     }
 
     private static void validateNotNull(

--- a/src/main/java/com/recyclestudy/review/repository/NotificationHistoryRepository.java
+++ b/src/main/java/com/recyclestudy/review/repository/NotificationHistoryRepository.java
@@ -8,12 +8,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Transactional;
 
 public interface NotificationHistoryRepository extends JpaRepository<NotificationHistory, Long> {
 
     @Modifying
-    @Transactional
     @Query("""
             UPDATE NotificationHistory nh
             SET nh.status = :status, nh.lastAttemptedAt = :now
@@ -26,7 +24,6 @@ public interface NotificationHistoryRepository extends JpaRepository<Notificatio
     );
 
     @Modifying
-    @Transactional
     @Query("""
             UPDATE NotificationHistory nh
             SET nh.status = :status, nh.failCount = nh.failCount + 1, nh.lastAttemptedAt = :now

--- a/src/main/java/com/recyclestudy/review/repository/NotificationHistoryRepository.java
+++ b/src/main/java/com/recyclestudy/review/repository/NotificationHistoryRepository.java
@@ -17,7 +17,7 @@ public interface NotificationHistoryRepository extends JpaRepository<Notificatio
             SET nh.status = :status, nh.lastAttemptedAt = :now
             WHERE nh.reviewCycle.id IN :reviewCycleIds
             """)
-    void updateStatus(
+    int updateStatus(
             @Param("reviewCycleIds") List<Long> reviewCycleIds,
             @Param("status") NotificationStatus status,
             @Param("now") LocalDateTime now
@@ -29,7 +29,7 @@ public interface NotificationHistoryRepository extends JpaRepository<Notificatio
             SET nh.status = :status, nh.failCount = nh.failCount + 1, nh.lastAttemptedAt = :now
             WHERE nh.reviewCycle.id IN :reviewCycleIds
             """)
-    void updateStatusWithIncrementFailCount(
+    int updateStatusWithIncrementFailCount(
             @Param("reviewCycleIds") List<Long> reviewCycleIds,
             @Param("status") NotificationStatus status,
             @Param("now") LocalDateTime now

--- a/src/main/java/com/recyclestudy/review/repository/NotificationHistoryRepository.java
+++ b/src/main/java/com/recyclestudy/review/repository/NotificationHistoryRepository.java
@@ -1,7 +1,40 @@
 package com.recyclestudy.review.repository;
 
 import com.recyclestudy.review.domain.NotificationHistory;
+import com.recyclestudy.review.domain.NotificationStatus;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface NotificationHistoryRepository extends JpaRepository<NotificationHistory, Long> {
+
+    @Modifying
+    @Transactional
+    @Query("""
+            UPDATE NotificationHistory nh
+            SET nh.status = :status, nh.lastAttemptedAt = :now
+            WHERE nh.reviewCycle.id IN :reviewCycleIds
+            """)
+    void updateStatus(
+            @Param("reviewCycleIds") List<Long> reviewCycleIds,
+            @Param("status") NotificationStatus status,
+            @Param("now") LocalDateTime now
+    );
+
+    @Modifying
+    @Transactional
+    @Query("""
+            UPDATE NotificationHistory nh
+            SET nh.status = :status, nh.failCount = nh.failCount + 1, nh.lastAttemptedAt = :now
+            WHERE nh.reviewCycle.id IN :reviewCycleIds
+            """)
+    void updateStatusWithIncrementFailCount(
+            @Param("reviewCycleIds") List<Long> reviewCycleIds,
+            @Param("status") NotificationStatus status,
+            @Param("now") LocalDateTime now
+    );
 }

--- a/src/main/java/com/recyclestudy/review/repository/NotificationHistoryRepository.java
+++ b/src/main/java/com/recyclestudy/review/repository/NotificationHistoryRepository.java
@@ -11,7 +11,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface NotificationHistoryRepository extends JpaRepository<NotificationHistory, Long> {
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("""
             UPDATE NotificationHistory nh
             SET nh.status = :status, nh.lastAttemptedAt = :now
@@ -23,7 +23,7 @@ public interface NotificationHistoryRepository extends JpaRepository<Notificatio
             @Param("now") LocalDateTime now
     );
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("""
             UPDATE NotificationHistory nh
             SET nh.status = :status, nh.failCount = nh.failCount + 1, nh.lastAttemptedAt = :now

--- a/src/main/java/com/recyclestudy/review/repository/ReviewCycleRepository.java
+++ b/src/main/java/com/recyclestudy/review/repository/ReviewCycleRepository.java
@@ -1,5 +1,6 @@
 package com.recyclestudy.review.repository;
 
+import com.recyclestudy.review.domain.NotificationStatus;
 import com.recyclestudy.review.domain.ReviewCycle;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -13,17 +14,27 @@ public interface ReviewCycleRepository extends JpaRepository<ReviewCycle, Long> 
             SELECT rc FROM ReviewCycle rc
             JOIN FETCH rc.review r
             JOIN FETCH r.member
-            WHERE rc.scheduledAt = :scheduledAt
+            JOIN NotificationHistory nh ON rc.id = nh.reviewCycle.id
+            WHERE rc.scheduledAt <= :scheduledAt
+            AND nh.status = :status
             """)
-    List<ReviewCycle> findAllByScheduledAt(@Param("scheduledAt") LocalDateTime scheduledAt);
+    List<ReviewCycle> findAllByScheduledAt(
+            @Param("scheduledAt") LocalDateTime scheduledAt,
+            @Param("status") NotificationStatus status
+    );
 
     @Query("""
             SELECT rc FROM ReviewCycle rc
+            JOIN FETCH rc.review r
+            JOIN FETCH r.member
             JOIN NotificationHistory nh ON rc.id = nh.reviewCycle.id
-            GROUP BY rc
-            HAVING SUM(CASE WHEN nh.status = 'SENT' THEN 1 ELSE 0 END) = 0
-            AND SUM(CASE WHEN nh.status = 'FAILED' THEN 1 ELSE 0 END) > 0
-            AND SUM(CASE WHEN nh.status = 'FAILED' THEN 1 ELSE 0 END) < :maxRetryCount
+            WHERE nh.status = :status
+            AND nh.failCount < :maxRetryCount
+            AND rc.scheduledAt <= :cutoffDateTime
             """)
-    List<ReviewCycle> findAllRetryableCycles(@Param("maxRetryCount") long maxRetryCount);
+    List<ReviewCycle> findAllRetryableCycles(
+            @Param("status") NotificationStatus status,
+            @Param("maxRetryCount") int maxRetryCount,
+            @Param("cutoffDateTime") LocalDateTime cutoffDateTime
+    );
 }

--- a/src/main/java/com/recyclestudy/review/service/NotificationHistoryService.java
+++ b/src/main/java/com/recyclestudy/review/service/NotificationHistoryService.java
@@ -21,19 +21,14 @@ public class NotificationHistoryService {
     @Transactional
     public void updateStatus(final List<Long> reviewCycleIds, final NotificationStatus status) {
         final LocalDateTime now = LocalDateTime.now(clock);
-        updateStatus(reviewCycleIds, status, now);
-        log.info("[NOTIFY_HIST_UPDATED] 알림 이력 상태 변경: status={}, count={}", status, reviewCycleIds.size());
-    }
-
-    private void updateStatus(
-            final List<Long> reviewCycleIds,
-            final NotificationStatus status,
-            final LocalDateTime now
-    ) {
-        if (status == NotificationStatus.FAILED) {
-            notificationHistoryRepository.updateStatusWithIncrementFailCount(reviewCycleIds, status, now);
+        if (reviewCycleIds.isEmpty()) {
             return;
         }
-        notificationHistoryRepository.updateStatus(reviewCycleIds, status, now);
+        if (status == NotificationStatus.FAILED) {
+            notificationHistoryRepository.updateStatusWithIncrementFailCount(reviewCycleIds, status, now);
+        } else {
+            notificationHistoryRepository.updateStatus(reviewCycleIds, status, now);
+        }
+        log.info("[NOTIFY_HIST_UPDATED] 알림 이력 상태 변경: status={}, count={}", status, reviewCycleIds.size());
     }
 }

--- a/src/main/java/com/recyclestudy/review/service/NotificationHistoryService.java
+++ b/src/main/java/com/recyclestudy/review/service/NotificationHistoryService.java
@@ -24,11 +24,17 @@ public class NotificationHistoryService {
         if (reviewCycleIds.isEmpty()) {
             return;
         }
+
+        int updated;
         if (status == NotificationStatus.FAILED) {
-            notificationHistoryRepository.updateStatusWithIncrementFailCount(reviewCycleIds, status, now);
+            updated = notificationHistoryRepository.updateStatusWithIncrementFailCount(reviewCycleIds, status, now);
         } else {
-            notificationHistoryRepository.updateStatus(reviewCycleIds, status, now);
+            updated = notificationHistoryRepository.updateStatus(reviewCycleIds, status, now);
         }
+        if (updated != reviewCycleIds.size()) {
+            log.warn("[NOTIFY_HIST_MISMATCH] 기대={}, 실제={}", reviewCycleIds.size(), updated);
+        }
+
         log.info("[NOTIFY_HIST_UPDATED] 알림 이력 상태 변경: status={}, count={}", status, reviewCycleIds.size());
     }
 }

--- a/src/main/java/com/recyclestudy/review/service/NotificationHistoryService.java
+++ b/src/main/java/com/recyclestudy/review/service/NotificationHistoryService.java
@@ -1,10 +1,9 @@
 package com.recyclestudy.review.service;
 
-import com.recyclestudy.review.domain.NotificationHistory;
 import com.recyclestudy.review.domain.NotificationStatus;
-import com.recyclestudy.review.domain.ReviewCycle;
 import com.recyclestudy.review.repository.NotificationHistoryRepository;
-import com.recyclestudy.review.repository.ReviewCycleRepository;
+import java.time.Clock;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,17 +16,24 @@ import org.springframework.transaction.annotation.Transactional;
 public class NotificationHistoryService {
 
     private final NotificationHistoryRepository notificationHistoryRepository;
-    private final ReviewCycleRepository reviewCycleRepository;
+    private final Clock clock;
 
     @Transactional
-    public void saveAll(final List<Long> reviewCycleIds, final NotificationStatus status) {
-        final List<ReviewCycle> reviewCycles = reviewCycleRepository.findAllById(reviewCycleIds);
+    public void updateStatus(final List<Long> reviewCycleIds, final NotificationStatus status) {
+        final LocalDateTime now = LocalDateTime.now(clock);
+        updateStatus(reviewCycleIds, status, now);
+        log.info("[NOTIFY_HIST_UPDATED] 알림 이력 상태 변경: status={}, count={}", status, reviewCycleIds.size());
+    }
 
-        final List<NotificationHistory> histories = reviewCycles.stream()
-                .map(cycle -> NotificationHistory.withoutId(cycle, status))
-                .toList();
-
-        notificationHistoryRepository.saveAll(histories);
-        log.info("[NOTIFY_HIST_UPDATED] 알림 이력 상태 변경: status={}, count={}", status, histories.size());
+    private void updateStatus(
+            final List<Long> reviewCycleIds,
+            final NotificationStatus status,
+            final LocalDateTime now
+    ) {
+        if (status == NotificationStatus.FAILED) {
+            notificationHistoryRepository.updateStatusWithIncrementFailCount(reviewCycleIds, status, now);
+            return;
+        }
+        notificationHistoryRepository.updateStatus(reviewCycleIds, status, now);
     }
 }

--- a/src/main/java/com/recyclestudy/review/service/NotificationHistoryService.java
+++ b/src/main/java/com/recyclestudy/review/service/NotificationHistoryService.java
@@ -20,11 +20,10 @@ public class NotificationHistoryService {
 
     @Transactional
     public void updateStatus(final List<Long> reviewCycleIds, final NotificationStatus status) {
-        final LocalDateTime now = LocalDateTime.now(clock);
         if (reviewCycleIds.isEmpty()) {
             return;
         }
-
+        final LocalDateTime now = LocalDateTime.now(clock);
         int updated;
         if (status == NotificationStatus.FAILED) {
             updated = notificationHistoryRepository.updateStatusWithIncrementFailCount(reviewCycleIds, status, now);
@@ -35,6 +34,6 @@ public class NotificationHistoryService {
             log.warn("[NOTIFY_HIST_MISMATCH] 기대={}, 실제={}", reviewCycleIds.size(), updated);
         }
 
-        log.info("[NOTIFY_HIST_UPDATED] 알림 이력 상태 변경: status={}, count={}", status, reviewCycleIds.size());
+        log.info("[NOTIFY_HIST_UPDATED] 알림 이력 상태 변경: status={}, count={}", status, updated);
     }
 }

--- a/src/main/java/com/recyclestudy/review/service/ReviewCycleService.java
+++ b/src/main/java/com/recyclestudy/review/service/ReviewCycleService.java
@@ -1,5 +1,6 @@
 package com.recyclestudy.review.service;
 
+import com.recyclestudy.review.domain.NotificationStatus;
 import com.recyclestudy.review.domain.ReviewCycle;
 import com.recyclestudy.review.repository.ReviewCycleRepository;
 import com.recyclestudy.review.service.input.ReviewSendInput;
@@ -17,7 +18,8 @@ public class ReviewCycleService {
 
     @Transactional(readOnly = true)
     public ReviewSendOutput findTargetReviewCycle(final ReviewSendInput input) {
-        final List<ReviewCycle> targetCycle = reviewCycleRepository.findAllByScheduledAt(input.scheduledAt());
+        final List<ReviewCycle> targetCycle = reviewCycleRepository.findAllByScheduledAt(
+                input.scheduledAt(), NotificationStatus.PENDING);
         return ReviewSendOutput.from(targetCycle);
     }
 }

--- a/src/main/resources/db/migration/V20260304_1__add_fail_count_and_last_attempted_at_to_notification_history.sql
+++ b/src/main/resources/db/migration/V20260304_1__add_fail_count_and_last_attempted_at_to_notification_history.sql
@@ -1,0 +1,3 @@
+ALTER TABLE notification_history
+    ADD COLUMN fail_count         INT      NOT NULL DEFAULT 0,
+    ADD COLUMN last_attempted_at  DATETIME NULL;

--- a/src/main/resources/db/migration/V20260304_2__migrate_notification_history_data.sql
+++ b/src/main/resources/db/migration/V20260304_2__migrate_notification_history_data.sql
@@ -1,0 +1,51 @@
+-- 기존 append-only 레코드를 review_cycle_id당 1개로 통합
+
+-- 1. PENDING 레코드(기준 레코드)에 fail_count 반영
+--    review_cycle_id별 FAILED 개수를 집계해서 PENDING 레코드에 update
+UPDATE notification_history nh
+JOIN (
+    SELECT review_cycle_id, COUNT(*) AS cnt
+    FROM notification_history
+    WHERE status = 'FAILED'
+    GROUP BY review_cycle_id
+) sub ON nh.review_cycle_id = sub.review_cycle_id
+SET nh.fail_count = sub.cnt
+WHERE nh.status = 'PENDING';
+
+-- 2. SENT가 있는 경우: PENDING → SENT 로 status 변경
+UPDATE notification_history nh
+JOIN (
+    SELECT DISTINCT review_cycle_id
+    FROM notification_history
+    WHERE status = 'SENT'
+) sub ON nh.review_cycle_id = sub.review_cycle_id
+SET nh.status = 'SENT'
+WHERE nh.status = 'PENDING';
+
+-- 3. SENT 없고 FAILED 있는 경우: PENDING → FAILED 로 status 변경
+UPDATE notification_history nh
+JOIN (
+    SELECT review_cycle_id, COUNT(*) AS cnt
+    FROM notification_history
+    WHERE status = 'FAILED'
+    GROUP BY review_cycle_id
+) sub ON nh.review_cycle_id = sub.review_cycle_id
+LEFT JOIN (
+    SELECT DISTINCT review_cycle_id
+    FROM notification_history
+    WHERE status = 'SENT'
+) sent ON nh.review_cycle_id = sent.review_cycle_id
+SET nh.status = 'FAILED'
+WHERE nh.status = 'PENDING'
+  AND sent.review_cycle_id IS NULL;
+
+-- 4. review_cycle_id당 MIN(id) 레코드 1개만 남기고 나머지 삭제
+--    PENDING이 항상 먼저 INSERT되므로 MIN(id) = 기준 레코드
+DELETE FROM notification_history
+WHERE id NOT IN (
+    SELECT min_id FROM (
+        SELECT MIN(id) AS min_id
+        FROM notification_history
+        GROUP BY review_cycle_id
+    ) AS keeper
+);

--- a/src/test/java/com/recyclestudy/email/EmailRetryServiceTest.java
+++ b/src/test/java/com/recyclestudy/email/EmailRetryServiceTest.java
@@ -2,10 +2,15 @@ package com.recyclestudy.email;
 
 import com.recyclestudy.member.domain.Email;
 import com.recyclestudy.member.domain.Member;
+import com.recyclestudy.review.domain.NotificationStatus;
 import com.recyclestudy.review.domain.Review;
 import com.recyclestudy.review.domain.ReviewCycle;
 import com.recyclestudy.review.domain.ReviewURL;
 import com.recyclestudy.review.repository.ReviewCycleRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -17,6 +22,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -32,6 +38,9 @@ class EmailRetryServiceTest {
     @Mock
     SingleReviewEmailSender singleReviewEmailSender;
 
+    @Mock
+    Clock clock;
+
     @InjectMocks
     EmailRetryService emailRetryService;
 
@@ -39,7 +48,11 @@ class EmailRetryServiceTest {
     @DisplayName("재시도 대상이 없으면 아무 동작도 하지 않는다")
     void retryFailedEmails_noData() {
         // given
-        given(reviewCycleRepository.findAllRetryableCycles(any(Long.class))).willReturn(Collections.emptyList());
+        given(clock.instant()).willReturn(Instant.parse("2026-01-01T00:00:00Z"));
+        given(clock.getZone()).willReturn(ZoneId.of("UTC"));
+        given(reviewCycleRepository.findAllRetryableCycles(
+                eq(NotificationStatus.FAILED), any(Integer.class), any(LocalDateTime.class)))
+                .willReturn(Collections.emptyList());
 
         // when
         emailRetryService.retryFailedEmails();
@@ -52,6 +65,9 @@ class EmailRetryServiceTest {
     @DisplayName("재시도 대상을 멤버별로 그룹화하여 메일을 발송한다")
     void retryFailedEmails_success() {
         // given
+        given(clock.instant()).willReturn(Instant.parse("2026-01-01T00:00:00Z"));
+        given(clock.getZone()).willReturn(ZoneId.of("UTC"));
+
         final Member member1 = mock(Member.class);
         final Email email1 = Email.from("user1@test.com");
         given(member1.getEmail()).willReturn(email1);
@@ -68,7 +84,8 @@ class EmailRetryServiceTest {
         given(cycle2.getId()).willReturn(2L);
         given(cycle2.getReview()).willReturn(review1);
 
-        given(reviewCycleRepository.findAllRetryableCycles(any(Long.class)))
+        given(reviewCycleRepository.findAllRetryableCycles(
+                eq(NotificationStatus.FAILED), any(Integer.class), any(LocalDateTime.class)))
                 .willReturn(List.of(cycle1, cycle2));
 
         // when

--- a/src/test/java/com/recyclestudy/email/SingleReviewEmailSenderTest.java
+++ b/src/test/java/com/recyclestudy/email/SingleReviewEmailSenderTest.java
@@ -55,7 +55,7 @@ class SingleReviewEmailSenderTest {
 
         // then
         verify(emailSender).send(eq(email), eq("[Recycle Study] 오늘의 복습 목록이 도착했습니다"), any());
-        verify(notificationHistoryService).saveAll(ids, NotificationStatus.SENT);
+        verify(notificationHistoryService).updateStatus(ids, NotificationStatus.SENT);
     }
 
     @Test
@@ -73,7 +73,7 @@ class SingleReviewEmailSenderTest {
         singleReviewEmailSender.sendOne(element);
 
         // then
-        verify(notificationHistoryService).saveAll(ids, NotificationStatus.FAILED);
+        verify(notificationHistoryService).updateStatus(ids, NotificationStatus.FAILED);
     }
 
     @Test

--- a/src/test/java/com/recyclestudy/review/repository/ReviewCycleRepositoryTest.java
+++ b/src/test/java/com/recyclestudy/review/repository/ReviewCycleRepositoryTest.java
@@ -32,93 +32,118 @@ class ReviewCycleRepositoryTest {
     @Autowired
     private ReviewRepository reviewRepository;
 
+    private static final LocalDateTime CUTOFF = LocalDateTime.now().minusDays(1);
+    private static final LocalDateTime LONG_AGO = LocalDateTime.now().minusDays(2);
+    private static final LocalDateTime RECENT = LocalDateTime.now().minusHours(1);
+
     @Test
-    @DisplayName("재시도 대상(실패 이력만 있고 최대 횟수 미만)을 조회한다")
+    @DisplayName("FAILED 상태이고 failCount가 최대 횟수 미만이면 재시도 대상에 포함된다")
     void findAllRetryableCycles_success() {
         // given
-        final Member member = memberRepository.save(Member.withoutId(Email.from("test@email.com")));
-        final Review review = reviewRepository.save(Review.withoutId(member, ReviewURL.from("url")));
-        final ReviewCycle cycle = reviewCycleRepository.save(ReviewCycle.withoutId(review, LocalDateTime.now()));
-
+        final ReviewCycle cycle = saveCycle("retry@email.com", LONG_AGO);
         notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.PENDING));
-        notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.FAILED));
+
+        notificationHistoryRepository.updateStatusWithIncrementFailCount(
+                List.of(cycle.getId()), NotificationStatus.FAILED, LocalDateTime.now());
 
         // when
-        final List<ReviewCycle> results = reviewCycleRepository.findAllRetryableCycles(3);
+        final List<ReviewCycle> results = reviewCycleRepository.findAllRetryableCycles(
+                NotificationStatus.FAILED, 3, CUTOFF);
 
         // then
         assertThat(results).hasSize(1);
-        assertThat(results.get(0).getId()).isEqualTo(cycle.getId());
+        assertThat(results.getFirst().getId()).isEqualTo(cycle.getId());
     }
 
     @Test
     @DisplayName("PENDING 상태만 있는 경우는 재시도 대상이 아니다")
     void findAllRetryableCycles_pendingOnly() {
         // given
-        final Member member = memberRepository.save(Member.withoutId(Email.from("pending@email.com")));
-        final Review review = reviewRepository.save(Review.withoutId(member, ReviewURL.from("url")));
-        final ReviewCycle cycle = reviewCycleRepository.save(ReviewCycle.withoutId(review, LocalDateTime.now()));
-
+        final ReviewCycle cycle = saveCycle("pending@email.com", LONG_AGO);
         notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.PENDING));
 
         // when
-        final List<ReviewCycle> results = reviewCycleRepository.findAllRetryableCycles(3);
+        final List<ReviewCycle> results = reviewCycleRepository.findAllRetryableCycles(
+                NotificationStatus.FAILED, 3, CUTOFF);
 
         // then
         assertThat(results).isEmpty();
     }
 
     @Test
-    @DisplayName("이미 성공한 이력이 있으면 재시도 대상이 아니다")
+    @DisplayName("이미 SENT 상태이면 재시도 대상이 아니다")
     void findAllRetryableCycles_alreadySent() {
         // given
-        final Member member = memberRepository.save(Member.withoutId(Email.from("sent@email.com")));
-        final Review review = reviewRepository.save(Review.withoutId(member, ReviewURL.from("url")));
-        final ReviewCycle cycle = reviewCycleRepository.save(ReviewCycle.withoutId(review, LocalDateTime.now()));
-
+        final ReviewCycle cycle = saveCycle("sent@email.com", LONG_AGO);
         notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.PENDING));
-        notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.FAILED));
-        notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.SENT));
+
+        notificationHistoryRepository.updateStatus(
+                List.of(cycle.getId()), NotificationStatus.SENT, LocalDateTime.now());
 
         // when
-        final List<ReviewCycle> results = reviewCycleRepository.findAllRetryableCycles(3);
+        final List<ReviewCycle> results = reviewCycleRepository.findAllRetryableCycles(
+                NotificationStatus.FAILED, 3, CUTOFF);
 
         // then
         assertThat(results).isEmpty();
     }
 
     @Test
-    @DisplayName("최대 재시도 횟수에 도달하면 재시도 대상이 아니다")
+    @DisplayName("failCount가 최대 재시도 횟수에 도달하면 재시도 대상이 아니다")
     void findAllRetryableCycles_maxRetryReached() {
         // given
-        final Member member = memberRepository.save(Member.withoutId(Email.from("max@email.com")));
-        final Review review = reviewRepository.save(Review.withoutId(member, ReviewURL.from("url")));
-        final ReviewCycle cycle = reviewCycleRepository.save(ReviewCycle.withoutId(review, LocalDateTime.now()));
-
+        final ReviewCycle cycle = saveCycle("max@email.com", LONG_AGO);
         notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.PENDING));
-        notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.FAILED));
-        notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.FAILED));
-        notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.FAILED));
+
+        // failCount를 3으로 만들기 위해 3번 increment
+        for (int i = 0; i < 3; i++) {
+            notificationHistoryRepository.updateStatusWithIncrementFailCount(
+                    List.of(cycle.getId()), NotificationStatus.FAILED, LocalDateTime.now());
+        }
 
         // when
-        final List<ReviewCycle> results = reviewCycleRepository.findAllRetryableCycles(3);
+        final List<ReviewCycle> results = reviewCycleRepository.findAllRetryableCycles(
+                NotificationStatus.FAILED, 3, CUTOFF);
 
         // then
         assertThat(results).isEmpty();
     }
 
     @Test
-    @DisplayName("이력이 없는 경우 재시도 대상이 아니다")
+    @DisplayName("notification_history가 없는 경우 재시도 대상이 아니다")
     void findAllRetryableCycles_noHistory() {
         // given
-        final Member member = memberRepository.save(Member.withoutId(Email.from("new@email.com")));
-        final Review review = reviewRepository.save(Review.withoutId(member, ReviewURL.from("url")));
-        reviewCycleRepository.save(ReviewCycle.withoutId(review, LocalDateTime.now()));
+        saveCycle("new@email.com", LONG_AGO);
 
         // when
-        final List<ReviewCycle> results = reviewCycleRepository.findAllRetryableCycles(3);
+        final List<ReviewCycle> results = reviewCycleRepository.findAllRetryableCycles(
+                NotificationStatus.FAILED, 3, CUTOFF);
 
         // then
         assertThat(results).isEmpty();
+    }
+
+    @Test
+    @DisplayName("scheduledAt이 cutoffDateTime보다 최근인 단기 주기는 재시도 대상이 아니다")
+    void findAllRetryableCycles_shortCycle() {
+        // given
+        final ReviewCycle cycle = saveCycle("short@email.com", RECENT);
+        notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.PENDING));
+
+        notificationHistoryRepository.updateStatusWithIncrementFailCount(
+                List.of(cycle.getId()), NotificationStatus.FAILED, LocalDateTime.now());
+
+        // when
+        final List<ReviewCycle> results = reviewCycleRepository.findAllRetryableCycles(
+                NotificationStatus.FAILED, 3, CUTOFF);
+
+        // then
+        assertThat(results).isEmpty();
+    }
+
+    private ReviewCycle saveCycle(final String email, final LocalDateTime scheduledAt) {
+        final Member member = memberRepository.save(Member.withoutId(Email.from(email)));
+        final Review review = reviewRepository.save(Review.withoutId(member, ReviewURL.from("url")));
+        return reviewCycleRepository.save(ReviewCycle.withoutId(review, scheduledAt));
     }
 }

--- a/src/test/java/com/recyclestudy/review/service/NotificationHistoryServiceTest.java
+++ b/src/test/java/com/recyclestudy/review/service/NotificationHistoryServiceTest.java
@@ -1,28 +1,22 @@
 package com.recyclestudy.review.service;
 
-import com.recyclestudy.member.domain.Email;
-import com.recyclestudy.member.domain.Member;
-import com.recyclestudy.review.domain.NotificationHistory;
 import com.recyclestudy.review.domain.NotificationStatus;
-import com.recyclestudy.review.domain.Review;
-import com.recyclestudy.review.domain.ReviewCycle;
-import com.recyclestudy.review.domain.ReviewURL;
 import com.recyclestudy.review.repository.NotificationHistoryRepository;
-import com.recyclestudy.review.repository.ReviewCycleRepository;
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
+import java.time.ZoneId;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
+import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.mockito.BDDMockito.given;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -32,57 +26,44 @@ class NotificationHistoryServiceTest {
     NotificationHistoryRepository notificationHistoryRepository;
 
     @Mock
-    ReviewCycleRepository reviewCycleRepository;
+    Clock clock;
 
     @InjectMocks
     NotificationHistoryService notificationHistoryService;
 
     @Test
-    @DisplayName("ReviewCycle ID 목록으로 NotificationHistory를 저장한다")
-    void saveAll() {
+    @DisplayName("SENT 상태로 업데이트한다")
+    void updateStatus_sent() {
         // given
         final List<Long> reviewCycleIds = List.of(1L, 2L);
-        final NotificationStatus status = NotificationStatus.SENT;
-
-        final Member member = Member.withoutId(Email.from("test@test.com"));
-        final Review review = Review.withoutId(member, ReviewURL.from("https://test.com"));
-
-        final LocalDateTime now = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES);
-        final ReviewCycle cycle1 = ReviewCycle.withoutId(review, now);
-        final ReviewCycle cycle2 = ReviewCycle.withoutId(review, now.plusDays(1));
-
-        given(reviewCycleRepository.findAllById(reviewCycleIds)).willReturn(List.of(cycle1, cycle2));
+        BDDMockito.given(clock.instant())
+                .willReturn(Instant.parse("2026-01-01T00:00:00Z"));
+        BDDMockito.given(clock.getZone())
+                .willReturn(ZoneId.of("UTC"));
 
         // when
-        notificationHistoryService.saveAll(reviewCycleIds, status);
+        notificationHistoryService.updateStatus(reviewCycleIds, NotificationStatus.SENT);
 
         // then
-        final ArgumentCaptor<List<NotificationHistory>> captor = ArgumentCaptor.forClass(List.class);
-        verify(notificationHistoryRepository).saveAll(captor.capture());
-
-        final List<NotificationHistory> savedHistories = captor.getValue();
-        assertSoftly(softAssertions -> {
-            softAssertions.assertThat(savedHistories).hasSize(2);
-            softAssertions.assertThat(savedHistories).allMatch(h -> h.getStatus() == NotificationStatus.SENT);
-        });
+        verify(notificationHistoryRepository).updateStatus(
+                eq(reviewCycleIds), eq(NotificationStatus.SENT), any(LocalDateTime.class));
     }
 
     @Test
-    @DisplayName("빈 ID 목록이면 빈 NotificationHistory 목록을 저장한다")
-    void saveAll_emptyIds() {
+    @DisplayName("FAILED 상태로 업데이트하면 failCount를 1 증가시킨다")
+    void updateStatus_failed() {
         // given
-        final List<Long> reviewCycleIds = List.of();
-        final NotificationStatus status = NotificationStatus.SENT;
-
-        given(reviewCycleRepository.findAllById(reviewCycleIds)).willReturn(List.of());
+        final List<Long> reviewCycleIds = List.of(1L);
+        BDDMockito.given(clock.instant())
+                .willReturn(Instant.parse("2026-01-01T00:00:00Z"));
+        BDDMockito.given(clock.getZone())
+                .willReturn(ZoneId.of("UTC"));
 
         // when
-        notificationHistoryService.saveAll(reviewCycleIds, status);
+        notificationHistoryService.updateStatus(reviewCycleIds, NotificationStatus.FAILED);
 
         // then
-        final ArgumentCaptor<List<NotificationHistory>> captor = ArgumentCaptor.forClass(List.class);
-        verify(notificationHistoryRepository).saveAll(captor.capture());
-
-        assertThat(captor.getValue()).isEmpty();
+        verify(notificationHistoryRepository).updateStatusWithIncrementFailCount(
+                eq(reviewCycleIds), eq(NotificationStatus.FAILED), any(LocalDateTime.class));
     }
 }

--- a/src/test/java/com/recyclestudy/review/service/ReviewCycleServiceTest.java
+++ b/src/test/java/com/recyclestudy/review/service/ReviewCycleServiceTest.java
@@ -2,6 +2,7 @@ package com.recyclestudy.review.service;
 
 import com.recyclestudy.member.domain.Email;
 import com.recyclestudy.member.domain.Member;
+import com.recyclestudy.review.domain.NotificationStatus;
 import com.recyclestudy.review.domain.Review;
 import com.recyclestudy.review.domain.ReviewCycle;
 import com.recyclestudy.review.domain.ReviewURL;
@@ -43,7 +44,7 @@ class ReviewCycleServiceTest {
         final Review review = Review.withoutId(member, ReviewURL.from("https://example.com/article"));
         final ReviewCycle reviewCycle = ReviewCycle.withoutId(review, scheduledAt);
 
-        given(reviewCycleRepository.findAllByScheduledAt(scheduledAt)).willReturn(List.of(reviewCycle));
+        given(reviewCycleRepository.findAllByScheduledAt(scheduledAt, NotificationStatus.PENDING)).willReturn(List.of(reviewCycle));
 
         // when
         final ReviewSendOutput result = reviewCycleService.findTargetReviewCycle(input);
@@ -53,7 +54,7 @@ class ReviewCycleServiceTest {
             softAssertions.assertThat(result.elements()).hasSize(1);
             softAssertions.assertThat(result.elements().getFirst().email()).isEqualTo(Email.from("user@test.com"));
         });
-        verify(reviewCycleRepository).findAllByScheduledAt(scheduledAt);
+        verify(reviewCycleRepository).findAllByScheduledAt(scheduledAt, NotificationStatus.PENDING);
     }
 
     @Test
@@ -63,7 +64,7 @@ class ReviewCycleServiceTest {
         final LocalDateTime scheduledAt = LocalDateTime.of(2025, 1, 1, 8, 0);
         final ReviewSendInput input = ReviewSendInput.from(scheduledAt);
 
-        given(reviewCycleRepository.findAllByScheduledAt(scheduledAt)).willReturn(List.of());
+        given(reviewCycleRepository.findAllByScheduledAt(scheduledAt, NotificationStatus.PENDING)).willReturn(List.of());
 
         // when
         final ReviewSendOutput result = reviewCycleService.findTargetReviewCycle(input);
@@ -85,7 +86,7 @@ class ReviewCycleServiceTest {
         final ReviewCycle cycle1 = ReviewCycle.withoutId(review1, scheduledAt);
         final ReviewCycle cycle2 = ReviewCycle.withoutId(review2, scheduledAt);
 
-        given(reviewCycleRepository.findAllByScheduledAt(scheduledAt)).willReturn(List.of(cycle1, cycle2));
+        given(reviewCycleRepository.findAllByScheduledAt(scheduledAt, NotificationStatus.PENDING)).willReturn(List.of(cycle1, cycle2));
 
         // when
         final ReviewSendOutput result = reviewCycleService.findTargetReviewCycle(input);
@@ -114,7 +115,7 @@ class ReviewCycleServiceTest {
         final ReviewCycle cycle1 = ReviewCycle.withoutId(review1, scheduledAt);
         final ReviewCycle cycle2 = ReviewCycle.withoutId(review2, scheduledAt);
 
-        given(reviewCycleRepository.findAllByScheduledAt(scheduledAt)).willReturn(List.of(cycle1, cycle2));
+        given(reviewCycleRepository.findAllByScheduledAt(scheduledAt, NotificationStatus.PENDING)).willReturn(List.of(cycle1, cycle2));
 
         // when
         final ReviewSendOutput result = reviewCycleService.findTargetReviewCycle(input);


### PR DESCRIPTION
<!-- PR 템플릿 -->

## 🚀 작업 내용

`notification_history`를 outbox 패턴으로 전환하여 이메일 발송 안정성을 개선.

### **데이터 모델 변경**
- `notification_history`에 `fail_count`, `last_attempted_at` 컬럼 추가
- append-only 구조 -> review_cycle_id당 레코드 1개 고정(UPDATE 방식)으로 전환
- Flyway 마이그레이션 2개 추가 (DDL, DML)

### **스케줄러 조회 쿼리 개선**
- `findAllByScheduledAt`: `scheduled_at` 정확 일치 → `<= now AND status = PENDING` 범위 조회
  - 서버 다운 시 PENDING 영구 누락 문제 해결
- `findAllRetryableCycles`: GROUP BY/HAVING 제거
  - `status = FAILED AND fail_count < 3 AND scheduled_at <= cutoff` 단순 조건
  - 단기 주기 재시도 제외

### **발송 결과 저장 방식 변경**
- `NotificationHistoryRepository`: `saveAll`(INSERT) -> `updateStatus` / `updateStatusWithIncrementFailCount`(UPDATE)
- `NotificationHistoryService`: `saveAll` -> `updateStatus` 호출로 전환
- `SingleReviewEmailSender`: 발송 성공/실패 분기에서 `updateStatus` 호출

### **재시도 로직 개선**
- `EmailRetryService`에 `Clock` 주입, `cutoffDateTime = now - 1일` 계산
- 단기 주기(1일 미만 경과) 재시도 자동 제외

## 📸 이슈 번호

- close #76 

## ✍ 궁금한 점

- `cutoffDateTime = now - 1일` 기준이 단기/장기 주기를 구분하는 프록시로 적절할까? 더 명확한 방법은 없을까?
  - 현재는 `review_cycle` 테이블에 주기 길이 컬럼이 없기 때문에 `scheduled_at` 경과 시간으로 역산
- `updateStatus` 벌크 UPDATE가 실패했을 때 at-least-once를 수용하는 현재 설계 외에, 재시도 횟수를 정확히 카운팅하는 더 좋은 방법이 있을까?
