### PR TITLE
다음 리뷰 전송 예정 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/recyclestudy/review/controller/ReviewController.java
+++ b/src/main/java/com/recyclestudy/review/controller/ReviewController.java
@@ -3,13 +3,18 @@ package com.recyclestudy.review.controller;
 import com.recyclestudy.common.annotation.AuthDevice;
 import com.recyclestudy.member.domain.DeviceIdentifier;
 import com.recyclestudy.review.controller.request.ReviewSaveRequest;
+import com.recyclestudy.review.controller.response.NextReviewResponse;
 import com.recyclestudy.review.controller.response.ReviewSaveResponse;
+import com.recyclestudy.review.service.ReviewCycleService;
 import com.recyclestudy.review.service.ReviewService;
+import com.recyclestudy.review.service.input.NextReviewInput;
 import com.recyclestudy.review.service.input.ReviewSaveInput;
+import com.recyclestudy.review.service.output.NextReviewOutput;
 import com.recyclestudy.review.service.output.ReviewSaveOutput;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ReviewController {
 
     private final ReviewService reviewService;
+    private final ReviewCycleService reviewCycleService;
 
     @PostMapping
     public ResponseEntity<ReviewSaveResponse> saveReview(
@@ -31,5 +37,13 @@ public class ReviewController {
         final ReviewSaveOutput output = reviewService.saveReview(input);
         ReviewSaveResponse response = ReviewSaveResponse.of(output.url(), output.scheduledAts());
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping("/next")
+    public ResponseEntity<NextReviewResponse> findNextReview(
+            @AuthDevice final DeviceIdentifier identifier
+    ) {
+        final NextReviewOutput output = reviewCycleService.findNextReview(NextReviewInput.from(identifier));
+        return ResponseEntity.ok(NextReviewResponse.of(output));
     }
 }

--- a/src/main/java/com/recyclestudy/review/controller/response/NextReviewResponse.java
+++ b/src/main/java/com/recyclestudy/review/controller/response/NextReviewResponse.java
@@ -1,0 +1,11 @@
+package com.recyclestudy.review.controller.response;
+
+import com.recyclestudy.review.service.output.NextReviewOutput;
+import java.time.LocalDateTime;
+
+public record NextReviewResponse(LocalDateTime scheduledAt, int count) {
+
+    public static NextReviewResponse of(final NextReviewOutput output) {
+        return new NextReviewResponse(output.scheduledAt(), output.count());
+    }
+}

--- a/src/main/java/com/recyclestudy/review/repository/NotificationHistoryRepository.java
+++ b/src/main/java/com/recyclestudy/review/repository/NotificationHistoryRepository.java
@@ -42,7 +42,7 @@ public interface NotificationHistoryRepository extends JpaRepository<Notificatio
             AND nh.status = :status
             ORDER BY rc.scheduledAt ASC
             """)
-    List<NotificationHistory> findAllPendingByMember(
+    List<NotificationHistory> findAllByMemberAndStatus(
             @Param("memberId") Long memberId,
             @Param("status") NotificationStatus status
     );

--- a/src/main/java/com/recyclestudy/review/repository/NotificationHistoryRepository.java
+++ b/src/main/java/com/recyclestudy/review/repository/NotificationHistoryRepository.java
@@ -34,4 +34,16 @@ public interface NotificationHistoryRepository extends JpaRepository<Notificatio
             @Param("status") NotificationStatus status,
             @Param("now") LocalDateTime now
     );
+
+    @Query("""
+            SELECT nh FROM NotificationHistory nh
+            JOIN FETCH nh.reviewCycle rc
+            WHERE rc.review.member.id = :memberId
+            AND nh.status = :status
+            ORDER BY rc.scheduledAt ASC
+            """)
+    List<NotificationHistory> findAllPendingByMember(
+            @Param("memberId") Long memberId,
+            @Param("status") NotificationStatus status
+    );
 }

--- a/src/main/java/com/recyclestudy/review/service/ReviewCycleService.java
+++ b/src/main/java/com/recyclestudy/review/service/ReviewCycleService.java
@@ -39,7 +39,7 @@ public class ReviewCycleService {
                 .orElseThrow(() -> new UnauthorizedException("유효하지 않은 디바이스입니다"));
 
         final List<NotificationHistory> allPending = notificationHistoryRepository
-                .findAllPendingByMember(member.getId(), NotificationStatus.PENDING);
+                .findAllByMemberAndStatus(member.getId(), NotificationStatus.PENDING);
 
         if (allPending.isEmpty()) {
             return NextReviewOutput.empty();

--- a/src/main/java/com/recyclestudy/review/service/ReviewCycleService.java
+++ b/src/main/java/com/recyclestudy/review/service/ReviewCycleService.java
@@ -1,10 +1,18 @@
 package com.recyclestudy.review.service;
 
+import com.recyclestudy.exception.UnauthorizedException;
+import com.recyclestudy.member.domain.Member;
+import com.recyclestudy.member.repository.MemberRepository;
+import com.recyclestudy.review.domain.NotificationHistory;
 import com.recyclestudy.review.domain.NotificationStatus;
 import com.recyclestudy.review.domain.ReviewCycle;
+import com.recyclestudy.review.repository.NotificationHistoryRepository;
 import com.recyclestudy.review.repository.ReviewCycleRepository;
+import com.recyclestudy.review.service.input.NextReviewInput;
 import com.recyclestudy.review.service.input.ReviewSendInput;
+import com.recyclestudy.review.service.output.NextReviewOutput;
 import com.recyclestudy.review.service.output.ReviewSendOutput;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,11 +23,33 @@ import org.springframework.transaction.annotation.Transactional;
 public class ReviewCycleService {
 
     private final ReviewCycleRepository reviewCycleRepository;
+    private final MemberRepository memberRepository;
+    private final NotificationHistoryRepository notificationHistoryRepository;
 
     @Transactional(readOnly = true)
     public ReviewSendOutput findTargetReviewCycle(final ReviewSendInput input) {
         final List<ReviewCycle> targetCycle = reviewCycleRepository.findAllByScheduledAt(
                 input.scheduledAt(), NotificationStatus.PENDING);
         return ReviewSendOutput.from(targetCycle);
+    }
+
+    @Transactional(readOnly = true)
+    public NextReviewOutput findNextReview(final NextReviewInput input) {
+        final Member member = memberRepository.findByIdentifier(input.identifier())
+                .orElseThrow(() -> new UnauthorizedException("유효하지 않은 디바이스입니다"));
+
+        final List<NotificationHistory> allPending = notificationHistoryRepository
+                .findAllPendingByMember(member.getId(), NotificationStatus.PENDING);
+
+        if (allPending.isEmpty()) {
+            return NextReviewOutput.empty();
+        }
+
+        final LocalDateTime earliest = allPending.getFirst().getReviewCycle().getScheduledAt();
+        final int count = (int) allPending.stream()
+                .takeWhile(nh -> nh.getReviewCycle().getScheduledAt().equals(earliest))
+                .count();
+
+        return NextReviewOutput.of(earliest, count);
     }
 }

--- a/src/main/java/com/recyclestudy/review/service/input/NextReviewInput.java
+++ b/src/main/java/com/recyclestudy/review/service/input/NextReviewInput.java
@@ -1,0 +1,10 @@
+package com.recyclestudy.review.service.input;
+
+import com.recyclestudy.member.domain.DeviceIdentifier;
+
+public record NextReviewInput(DeviceIdentifier identifier) {
+
+    public static NextReviewInput from(final DeviceIdentifier identifier) {
+        return new NextReviewInput(identifier);
+    }
+}

--- a/src/main/java/com/recyclestudy/review/service/output/NextReviewOutput.java
+++ b/src/main/java/com/recyclestudy/review/service/output/NextReviewOutput.java
@@ -1,0 +1,14 @@
+package com.recyclestudy.review.service.output;
+
+import java.time.LocalDateTime;
+
+public record NextReviewOutput(LocalDateTime scheduledAt, int count) {
+
+    public static NextReviewOutput empty() {
+        return new NextReviewOutput(null, 0);
+    }
+
+    public static NextReviewOutput of(final LocalDateTime scheduledAt, final int count) {
+        return new NextReviewOutput(scheduledAt, count);
+    }
+}

--- a/src/test/java/com/recyclestudy/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/recyclestudy/review/controller/ReviewControllerTest.java
@@ -12,7 +12,9 @@ import com.recyclestudy.member.repository.DeviceRepository;
 import com.recyclestudy.restdocs.APIBaseTest;
 import com.recyclestudy.review.controller.request.ReviewSaveRequest;
 import com.recyclestudy.review.domain.ReviewURL;
+import com.recyclestudy.review.service.ReviewCycleService;
 import com.recyclestudy.review.service.ReviewService;
+import com.recyclestudy.review.service.output.NextReviewOutput;
 import com.recyclestudy.review.service.output.ReviewSaveOutput;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -40,6 +42,9 @@ class ReviewControllerTest extends APIBaseTest {
 
     @MockitoBean
     private ReviewService reviewService;
+
+    @MockitoBean
+    private ReviewCycleService reviewCycleService;
 
     @MockitoBean
     private DeviceRepository deviceRepository;
@@ -244,5 +249,98 @@ class ReviewControllerTest extends APIBaseTest {
                 .then()
                 .statusCode(HttpStatus.UNAUTHORIZED.value())
                 .body("message", equalTo("인증되지 않은 디바이스입니다"));
+    }
+
+    @Test
+    @DisplayName("다음 리뷰 조회 시 200 응답과 scheduledAt, count를 반환한다")
+    void findNextReview_success() {
+        // given
+        final String identifier = "device-id";
+        final LocalDateTime scheduledAt = LocalDateTime.of(2026, 3, 6, 9, 0);
+        final NextReviewOutput output = NextReviewOutput.of(scheduledAt, 3);
+
+        given(reviewCycleService.findNextReview(any())).willReturn(output);
+
+        // when
+        // then
+        given(this.spec)
+                .filter(document(DEFAULT_REST_DOC_PATH,
+                        builder()
+                                .tag("Review")
+                                .summary("다음 리뷰 조회")
+                                .description("다음 발송 예정 시간과 URL 개수를 반환한다")
+                                .requestHeaders(
+                                        headerWithName("X-Device-Id").description("디바이스 식별자")
+                                )
+                                .responseFields(
+                                        fieldWithPath("scheduledAt").type(JsonFieldType.STRING)
+                                                .description("다음 발송 예정 시간 (PENDING 없을 시 null)"),
+                                        fieldWithPath("count").type(JsonFieldType.NUMBER)
+                                                .description("해당 시간에 발송될 URL 개수")
+                                )
+                ))
+                .header("X-Device-Id", identifier)
+                .when()
+                .get("/api/v1/reviews/next")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .body("count", equalTo(3));
+    }
+
+    @Test
+    @DisplayName("PENDING이 없을 때 200 응답과 scheduledAt=null, count=0을 반환한다")
+    void findNextReview_empty() {
+        // given
+        final String identifier = "device-id";
+        final NextReviewOutput output = NextReviewOutput.empty();
+
+        given(reviewCycleService.findNextReview(any())).willReturn(output);
+
+        // when
+        // then
+        given(this.spec)
+                .filter(document(DEFAULT_REST_DOC_PATH,
+                        builder()
+                                .tag("Review")
+                                .summary("다음 리뷰 조회")
+                                .description("PENDING이 없을 때 scheduledAt=null, count=0을 반환한다")
+                                .requestHeaders(
+                                        headerWithName("X-Device-Id").description("디바이스 식별자")
+                                )
+                                .responseFields(
+                                        fieldWithPath("scheduledAt").type(JsonFieldType.NULL)
+                                                .description("다음 발송 예정 시간 (PENDING 없을 시 null)"),
+                                        fieldWithPath("count").type(JsonFieldType.NUMBER)
+                                                .description("해당 시간에 발송될 URL 개수")
+                                )
+                ))
+                .header("X-Device-Id", identifier)
+                .when()
+                .get("/api/v1/reviews/next")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .body("scheduledAt", equalTo(null))
+                .body("count", equalTo(0));
+    }
+
+    @Test
+    @DisplayName("헤더 없이 다음 리뷰 조회 시 401 응답을 반환한다")
+    void findNextReview_noHeader() {
+        // when
+        // then
+        given(this.spec)
+                .filter(document(DEFAULT_REST_DOC_PATH,
+                        builder()
+                                .tag("Review")
+                                .summary("다음 리뷰 조회")
+                                .description("헤더 없이 다음 리뷰 조회 시 401 응답을 반환한다")
+                                .responseFields(
+                                        fieldWithPath("message").type(JsonFieldType.STRING).description("에러 메시지")
+                                )
+                ))
+                .when()
+                .get("/api/v1/reviews/next")
+                .then()
+                .statusCode(HttpStatus.UNAUTHORIZED.value());
     }
 }

--- a/src/test/java/com/recyclestudy/review/repository/NotificationHistoryRepositoryTest.java
+++ b/src/test/java/com/recyclestudy/review/repository/NotificationHistoryRepositoryTest.java
@@ -38,7 +38,7 @@ class NotificationHistoryRepositoryTest {
 
     @Test
     @DisplayName("본인의 PENDING NotificationHistory가 scheduledAt ASC 순으로 반환된다")
-    void findAllPendingByMember_pendingAscOrder() {
+    void findAllPendingByMember_AscOrderAndStatus() {
         // given
         final Member member = saveMember("user@test.com");
         saveNh(member, T2, NotificationStatus.PENDING);
@@ -46,7 +46,7 @@ class NotificationHistoryRepositoryTest {
 
         // when
         final List<NotificationHistory> result = notificationHistoryRepository
-                .findAllPendingByMember(member.getId(), NotificationStatus.PENDING);
+                .findAllByMemberAndStatus(member.getId(), NotificationStatus.PENDING);
 
         // then
         assertSoftly(softly -> {
@@ -58,7 +58,7 @@ class NotificationHistoryRepositoryTest {
 
     @Test
     @DisplayName("타 멤버의 NotificationHistory는 포함되지 않는다")
-    void findAllPendingByMember_excludesOtherMembers() {
+    void findAllByMember_AndStatus_excludesOtherMembers() {
         // given
         final Member member = saveMember("user@test.com");
         final Member other = saveMember("other@test.com");
@@ -67,7 +67,7 @@ class NotificationHistoryRepositoryTest {
 
         // when
         final List<NotificationHistory> result = notificationHistoryRepository
-                .findAllPendingByMember(member.getId(), NotificationStatus.PENDING);
+                .findAllByMemberAndStatus(member.getId(), NotificationStatus.PENDING);
 
         // then
         assertThat(result).hasSize(1);
@@ -76,7 +76,7 @@ class NotificationHistoryRepositoryTest {
 
     @Test
     @DisplayName("SENT/FAILED 상태는 조회에서 제외된다")
-    void findAllPendingByMember_excludesNonPending() {
+    void findAllPendingByMember_excludesNonAndStatus() {
         // given
         final Member member = saveMember("user@test.com");
         saveNh(member, T1, NotificationStatus.SENT);
@@ -84,7 +84,7 @@ class NotificationHistoryRepositoryTest {
 
         // when
         final List<NotificationHistory> result = notificationHistoryRepository
-                .findAllPendingByMember(member.getId(), NotificationStatus.PENDING);
+                .findAllByMemberAndStatus(member.getId(), NotificationStatus.PENDING);
 
         // then
         assertThat(result).isEmpty();
@@ -92,13 +92,13 @@ class NotificationHistoryRepositoryTest {
 
     @Test
     @DisplayName("NotificationHistory가 없으면 빈 리스트를 반환한다")
-    void findAllPendingByMember_empty() {
+    void findAllByMember_AndStatus_empty() {
         // given
         final Member member = saveMember("user@test.com");
 
         // when
         final List<NotificationHistory> result = notificationHistoryRepository
-                .findAllPendingByMember(member.getId(), NotificationStatus.PENDING);
+                .findAllByMemberAndStatus(member.getId(), NotificationStatus.PENDING);
 
         // then
         assertThat(result).isEmpty();

--- a/src/test/java/com/recyclestudy/review/repository/NotificationHistoryRepositoryTest.java
+++ b/src/test/java/com/recyclestudy/review/repository/NotificationHistoryRepositoryTest.java
@@ -1,0 +1,117 @@
+package com.recyclestudy.review.repository;
+
+import com.recyclestudy.member.domain.Email;
+import com.recyclestudy.member.domain.Member;
+import com.recyclestudy.member.repository.MemberRepository;
+import com.recyclestudy.review.domain.NotificationHistory;
+import com.recyclestudy.review.domain.NotificationStatus;
+import com.recyclestudy.review.domain.Review;
+import com.recyclestudy.review.domain.ReviewCycle;
+import com.recyclestudy.review.domain.ReviewURL;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@DataJpaTest
+class NotificationHistoryRepositoryTest {
+
+    @Autowired
+    private NotificationHistoryRepository notificationHistoryRepository;
+
+    @Autowired
+    private ReviewCycleRepository reviewCycleRepository;
+
+    @Autowired
+    private ReviewRepository reviewRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private static final LocalDateTime T1 = LocalDateTime.of(2026, 3, 6, 9, 0);
+    private static final LocalDateTime T2 = LocalDateTime.of(2026, 3, 7, 9, 0);
+
+    @Test
+    @DisplayName("본인의 PENDING NotificationHistory가 scheduledAt ASC 순으로 반환된다")
+    void findAllPendingByMember_pendingAscOrder() {
+        // given
+        final Member member = saveMember("user@test.com");
+        saveNh(member, T2, NotificationStatus.PENDING);
+        saveNh(member, T1, NotificationStatus.PENDING);
+
+        // when
+        final List<NotificationHistory> result = notificationHistoryRepository
+                .findAllPendingByMember(member.getId(), NotificationStatus.PENDING);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result).hasSize(2);
+            softly.assertThat(result.get(0).getReviewCycle().getScheduledAt()).isEqualTo(T1);
+            softly.assertThat(result.get(1).getReviewCycle().getScheduledAt()).isEqualTo(T2);
+        });
+    }
+
+    @Test
+    @DisplayName("타 멤버의 NotificationHistory는 포함되지 않는다")
+    void findAllPendingByMember_excludesOtherMembers() {
+        // given
+        final Member member = saveMember("user@test.com");
+        final Member other = saveMember("other@test.com");
+        saveNh(member, T1, NotificationStatus.PENDING);
+        saveNh(other, T1, NotificationStatus.PENDING);
+
+        // when
+        final List<NotificationHistory> result = notificationHistoryRepository
+                .findAllPendingByMember(member.getId(), NotificationStatus.PENDING);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().getReviewCycle().getScheduledAt()).isEqualTo(T1);
+    }
+
+    @Test
+    @DisplayName("SENT/FAILED 상태는 조회에서 제외된다")
+    void findAllPendingByMember_excludesNonPending() {
+        // given
+        final Member member = saveMember("user@test.com");
+        saveNh(member, T1, NotificationStatus.SENT);
+        saveNh(member, T2, NotificationStatus.FAILED);
+
+        // when
+        final List<NotificationHistory> result = notificationHistoryRepository
+                .findAllPendingByMember(member.getId(), NotificationStatus.PENDING);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("NotificationHistory가 없으면 빈 리스트를 반환한다")
+    void findAllPendingByMember_empty() {
+        // given
+        final Member member = saveMember("user@test.com");
+
+        // when
+        final List<NotificationHistory> result = notificationHistoryRepository
+                .findAllPendingByMember(member.getId(), NotificationStatus.PENDING);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    private Member saveMember(final String email) {
+        return memberRepository.save(Member.withoutId(Email.from(email)));
+    }
+
+    private NotificationHistory saveNh(final Member member, final LocalDateTime scheduledAt,
+                                       final NotificationStatus status) {
+        final Review review = reviewRepository.save(Review.withoutId(member, ReviewURL.from("https://example.com")));
+        final ReviewCycle cycle = reviewCycleRepository.save(ReviewCycle.withoutId(review, scheduledAt));
+        return notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, status));
+    }
+}

--- a/src/test/java/com/recyclestudy/review/service/ReviewCycleServiceTest.java
+++ b/src/test/java/com/recyclestudy/review/service/ReviewCycleServiceTest.java
@@ -1,17 +1,25 @@
 package com.recyclestudy.review.service;
 
+import com.recyclestudy.exception.UnauthorizedException;
+import com.recyclestudy.member.domain.DeviceIdentifier;
 import com.recyclestudy.member.domain.Email;
 import com.recyclestudy.member.domain.Member;
+import com.recyclestudy.member.repository.MemberRepository;
+import com.recyclestudy.review.domain.NotificationHistory;
 import com.recyclestudy.review.domain.NotificationStatus;
 import com.recyclestudy.review.domain.Review;
 import com.recyclestudy.review.domain.ReviewCycle;
 import com.recyclestudy.review.domain.ReviewURL;
+import com.recyclestudy.review.repository.NotificationHistoryRepository;
 import com.recyclestudy.review.repository.ReviewCycleRepository;
+import com.recyclestudy.review.service.input.NextReviewInput;
 import com.recyclestudy.review.service.input.ReviewSendInput;
+import com.recyclestudy.review.service.output.NextReviewOutput;
 import com.recyclestudy.review.service.output.ReviewSendOutput;
 import com.recyclestudy.review.service.output.ReviewSendOutput.ReviewSendElement;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,6 +28,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -29,6 +38,12 @@ class ReviewCycleServiceTest {
 
     @Mock
     private ReviewCycleRepository reviewCycleRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private NotificationHistoryRepository notificationHistoryRepository;
 
     @InjectMocks
     private ReviewCycleService reviewCycleService;
@@ -44,7 +59,8 @@ class ReviewCycleServiceTest {
         final Review review = Review.withoutId(member, ReviewURL.from("https://example.com/article"));
         final ReviewCycle reviewCycle = ReviewCycle.withoutId(review, scheduledAt);
 
-        given(reviewCycleRepository.findAllByScheduledAt(scheduledAt, NotificationStatus.PENDING)).willReturn(List.of(reviewCycle));
+        given(reviewCycleRepository.findAllByScheduledAt(scheduledAt, NotificationStatus.PENDING)).willReturn(
+                List.of(reviewCycle));
 
         // when
         final ReviewSendOutput result = reviewCycleService.findTargetReviewCycle(input);
@@ -64,7 +80,8 @@ class ReviewCycleServiceTest {
         final LocalDateTime scheduledAt = LocalDateTime.of(2025, 1, 1, 8, 0);
         final ReviewSendInput input = ReviewSendInput.from(scheduledAt);
 
-        given(reviewCycleRepository.findAllByScheduledAt(scheduledAt, NotificationStatus.PENDING)).willReturn(List.of());
+        given(reviewCycleRepository.findAllByScheduledAt(scheduledAt, NotificationStatus.PENDING)).willReturn(
+                List.of());
 
         // when
         final ReviewSendOutput result = reviewCycleService.findTargetReviewCycle(input);
@@ -86,7 +103,8 @@ class ReviewCycleServiceTest {
         final ReviewCycle cycle1 = ReviewCycle.withoutId(review1, scheduledAt);
         final ReviewCycle cycle2 = ReviewCycle.withoutId(review2, scheduledAt);
 
-        given(reviewCycleRepository.findAllByScheduledAt(scheduledAt, NotificationStatus.PENDING)).willReturn(List.of(cycle1, cycle2));
+        given(reviewCycleRepository.findAllByScheduledAt(scheduledAt, NotificationStatus.PENDING)).willReturn(
+                List.of(cycle1, cycle2));
 
         // when
         final ReviewSendOutput result = reviewCycleService.findTargetReviewCycle(input);
@@ -115,7 +133,8 @@ class ReviewCycleServiceTest {
         final ReviewCycle cycle1 = ReviewCycle.withoutId(review1, scheduledAt);
         final ReviewCycle cycle2 = ReviewCycle.withoutId(review2, scheduledAt);
 
-        given(reviewCycleRepository.findAllByScheduledAt(scheduledAt, NotificationStatus.PENDING)).willReturn(List.of(cycle1, cycle2));
+        given(reviewCycleRepository.findAllByScheduledAt(scheduledAt, NotificationStatus.PENDING)).willReturn(
+                List.of(cycle1, cycle2));
 
         // when
         final ReviewSendOutput result = reviewCycleService.findTargetReviewCycle(input);
@@ -132,5 +151,103 @@ class ReviewCycleServiceTest {
                     Email.from("user2@test.com")
             );
         });
+    }
+
+    @Test
+    @DisplayName("PENDING이 없을 때 empty()를 반환한다")
+    void findNextReview_empty() {
+        // given
+        final DeviceIdentifier identifier = DeviceIdentifier.from("device-id");
+        final NextReviewInput input = NextReviewInput.from(identifier);
+        final Member member = Member.withoutId(Email.from("user@test.com"));
+
+        given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.of(member));
+        given(notificationHistoryRepository.findAllPendingByMember(member.getId(), NotificationStatus.PENDING))
+                .willReturn(List.of());
+
+        // when
+        final NextReviewOutput result = reviewCycleService.findNextReview(input);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.scheduledAt()).isNull();
+            softly.assertThat(result.count()).isEqualTo(0);
+        });
+    }
+
+    @Test
+    @DisplayName("가장 빠른 시간 그룹 count만 반환한다")
+    void findNextReview_returnsEarliestGroup() {
+        // given
+        final DeviceIdentifier identifier = DeviceIdentifier.from("device-id");
+        final NextReviewInput input = NextReviewInput.from(identifier);
+        final Member member = Member.withoutId(Email.from("user@test.com"));
+        final LocalDateTime t1 = LocalDateTime.of(2026, 3, 6, 9, 0);
+        final LocalDateTime t2 = LocalDateTime.of(2026, 3, 7, 9, 0);
+
+        final Review review = Review.withoutId(member, ReviewURL.from("https://example.com"));
+        final NotificationHistory nh1 = NotificationHistory.withoutId(ReviewCycle.withoutId(review, t1),
+                NotificationStatus.PENDING);
+        final NotificationHistory nh2 = NotificationHistory.withoutId(ReviewCycle.withoutId(review, t2),
+                NotificationStatus.PENDING);
+
+        given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.of(member));
+        given(notificationHistoryRepository.findAllPendingByMember(member.getId(), NotificationStatus.PENDING))
+                .willReturn(List.of(nh1, nh2));
+
+        // when
+        final NextReviewOutput result = reviewCycleService.findNextReview(input);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.scheduledAt()).isEqualTo(t1);
+            softly.assertThat(result.count()).isEqualTo(1);
+        });
+    }
+
+    @Test
+    @DisplayName("같은 scheduledAt의 여러 NotificationHistory count를 정확히 집계한다")
+    void findNextReview_countsSameScheduledAt() {
+        // given
+        final DeviceIdentifier identifier = DeviceIdentifier.from("device-id");
+        final NextReviewInput input = NextReviewInput.from(identifier);
+        final Member member = Member.withoutId(Email.from("user@test.com"));
+        final LocalDateTime t1 = LocalDateTime.of(2026, 3, 6, 9, 0);
+
+        final Review review = Review.withoutId(member, ReviewURL.from("https://example.com"));
+        final NotificationHistory nh1 = NotificationHistory.withoutId(ReviewCycle.withoutId(review, t1),
+                NotificationStatus.PENDING);
+        final NotificationHistory nh2 = NotificationHistory.withoutId(ReviewCycle.withoutId(review, t1),
+                NotificationStatus.PENDING);
+        final NotificationHistory nh3 = NotificationHistory.withoutId(ReviewCycle.withoutId(review, t1),
+                NotificationStatus.PENDING);
+
+        given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.of(member));
+        given(notificationHistoryRepository.findAllPendingByMember(member.getId(), NotificationStatus.PENDING))
+                .willReturn(List.of(nh1, nh2, nh3));
+
+        // when
+        final NextReviewOutput result = reviewCycleService.findNextReview(input);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.scheduledAt()).isEqualTo(t1);
+            softly.assertThat(result.count()).isEqualTo(3);
+        });
+    }
+
+    @Test
+    @DisplayName("미등록 identifier이면 UnauthorizedException을 던진다")
+    void findNextReview_unauthorized() {
+        // given
+        final DeviceIdentifier identifier = DeviceIdentifier.from("unknown-id");
+        final NextReviewInput input = NextReviewInput.from(identifier);
+
+        given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.empty());
+
+        // when
+        // then
+        assertThatThrownBy(() -> reviewCycleService.findNextReview(input))
+                .isInstanceOf(UnauthorizedException.class);
     }
 }

--- a/src/test/java/com/recyclestudy/review/service/ReviewCycleServiceTest.java
+++ b/src/test/java/com/recyclestudy/review/service/ReviewCycleServiceTest.java
@@ -162,7 +162,7 @@ class ReviewCycleServiceTest {
         final Member member = Member.withoutId(Email.from("user@test.com"));
 
         given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.of(member));
-        given(notificationHistoryRepository.findAllPendingByMember(member.getId(), NotificationStatus.PENDING))
+        given(notificationHistoryRepository.findAllByMemberAndStatus(member.getId(), NotificationStatus.PENDING))
                 .willReturn(List.of());
 
         // when
@@ -192,7 +192,7 @@ class ReviewCycleServiceTest {
                 NotificationStatus.PENDING);
 
         given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.of(member));
-        given(notificationHistoryRepository.findAllPendingByMember(member.getId(), NotificationStatus.PENDING))
+        given(notificationHistoryRepository.findAllByMemberAndStatus(member.getId(), NotificationStatus.PENDING))
                 .willReturn(List.of(nh1, nh2));
 
         // when
@@ -223,7 +223,7 @@ class ReviewCycleServiceTest {
                 NotificationStatus.PENDING);
 
         given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.of(member));
-        given(notificationHistoryRepository.findAllPendingByMember(member.getId(), NotificationStatus.PENDING))
+        given(notificationHistoryRepository.findAllByMemberAndStatus(member.getId(), NotificationStatus.PENDING))
                 .willReturn(List.of(nh1, nh2, nh3));
 
         // when


### PR DESCRIPTION
<!-- PR 템플릿 -->

## 🚀 작업 내용

메인 화면 상단에 "다음 발송 예정 시간과 URL 개수"를 표시하기 위한 `GET /api/v1/reviews/next` API를 구현.

**`NotificationHistoryRepository`**
- `findAllPendingByMember(memberId, status)` JPQL 추가
- `JOIN FETCH nh.reviewCycle` + `ORDER BY rc.scheduledAt ASC` 정렬

**`ReviewCycleService`**
- `MemberRepository`, `NotificationHistoryRepository` 의존성 추가
- `findNextReview(NextReviewInput)` 구현
  - PENDING 목록을 ASC 정렬로 조회 후 첫 번째 `scheduledAt` 기준 `takeWhile`로 count 집계

**`ReviewController`**
- `ReviewCycleService` 의존성 추가
- `GET /api/v1/reviews/next` 엔드포인트 추가

#### 응답 명세

```json
// PENDING 있을 때
{ "scheduledAt": "2026-03-06T09:00:00", "count": 3 }

// PENDING 없을 때
{ "scheduledAt": null, "count": 0 }
```

## 📸 이슈 번호

- close #78 

## ✍ 궁금한 점

- `takeWhile`을 사용하여 가장 이른 그룹만 count하는 방식이 적절한지
  - DB에서 ASC 정렬 후 애플리케이션 레벨에서 처리하는 방식 vs DB에서 `MIN(scheduledAt)` 서브쿼리로 처리하는 방식 중 어느 쪽이 더 나을지?