### PR TITLE
Gmail SMTP에서 AWS SES SDK v2로 이메일 발송 인프라 교체

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,9 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation platform('software.amazon.awssdk:bom:2.29.52')
+    implementation 'software.amazon.awssdk:sesv2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/recyclestudy/common/config/AwsSesConfig.java
+++ b/src/main/java/com/recyclestudy/common/config/AwsSesConfig.java
@@ -1,0 +1,19 @@
+package com.recyclestudy.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sesv2.SesV2Client;
+
+@Configuration
+public class AwsSesConfig {
+
+    @Bean
+    public SesV2Client sesV2Client() {
+        return SesV2Client.builder()
+                .region(Region.AP_NORTHEAST_2)
+                .credentialsProvider(DefaultCredentialsProvider.create())
+                .build();
+    }
+}

--- a/src/main/java/com/recyclestudy/email/EmailSender.java
+++ b/src/main/java/com/recyclestudy/email/EmailSender.java
@@ -5,6 +5,7 @@ import com.recyclestudy.member.domain.Email;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.sesv2.SesV2Client;
 import software.amazon.awssdk.services.sesv2.model.Body;
 import software.amazon.awssdk.services.sesv2.model.Content;
@@ -12,7 +13,6 @@ import software.amazon.awssdk.services.sesv2.model.Destination;
 import software.amazon.awssdk.services.sesv2.model.EmailContent;
 import software.amazon.awssdk.services.sesv2.model.Message;
 import software.amazon.awssdk.services.sesv2.model.SendEmailRequest;
-import software.amazon.awssdk.services.sesv2.model.SesV2Exception;
 
 @Slf4j
 @Component
@@ -41,7 +41,7 @@ public class EmailSender {
         try {
             sesV2Client.sendEmail(request);
             log.info("[MAIL_SENT] 메일 발송 성공: email={}", targetEmail.toMaskedValue());
-        } catch (final SesV2Exception e) {
+        } catch (final SdkException e) {
             log.error("[MAIL_SEND_FAILED] 메일 발송 실패: email={}", targetEmail.toMaskedValue(), e);
             throw new EmailSendException("메일 전송 중 오류가 발생했습니다.", e);
         }

--- a/src/main/java/com/recyclestudy/email/EmailSender.java
+++ b/src/main/java/com/recyclestudy/email/EmailSender.java
@@ -2,33 +2,46 @@ package com.recyclestudy.email;
 
 import com.recyclestudy.exception.EmailSendException;
 import com.recyclestudy.member.domain.Email;
-import jakarta.mail.MessagingException;
-import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.sesv2.SesV2Client;
+import software.amazon.awssdk.services.sesv2.model.Body;
+import software.amazon.awssdk.services.sesv2.model.Content;
+import software.amazon.awssdk.services.sesv2.model.Destination;
+import software.amazon.awssdk.services.sesv2.model.EmailContent;
+import software.amazon.awssdk.services.sesv2.model.Message;
+import software.amazon.awssdk.services.sesv2.model.SendEmailRequest;
+import software.amazon.awssdk.services.sesv2.model.SesV2Exception;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class EmailSender {
 
-    private final JavaMailSender javaMailSender;
+    private static final String FROM_ADDRESS = "noreply@recycle-study.site";
+
+    private final SesV2Client sesV2Client;
 
     public void send(final Email targetEmail, final String subject, final String content) {
+        final SendEmailRequest request = SendEmailRequest.builder()
+                .fromEmailAddress(FROM_ADDRESS)
+                .destination(Destination.builder()
+                        .toAddresses(targetEmail.getValue())
+                        .build())
+                .content(EmailContent.builder()
+                        .simple(Message.builder()
+                                .subject(Content.builder().data(subject).charset("UTF-8").build())
+                                .body(Body.builder()
+                                        .html(Content.builder().data(content).charset("UTF-8").build())
+                                        .build())
+                                .build())
+                        .build())
+                .build();
         try {
-            final MimeMessage mimeMessage = javaMailSender.createMimeMessage();
-            final MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
-
-            helper.setTo(targetEmail.getValue());
-            helper.setSubject(subject);
-            helper.setText(content, true);
-
-            javaMailSender.send(mimeMessage);
+            sesV2Client.sendEmail(request);
             log.info("[MAIL_SENT] 메일 발송 성공: email={}", targetEmail.toMaskedValue());
-        } catch (MessagingException e) {
+        } catch (final SesV2Exception e) {
             log.error("[MAIL_SEND_FAILED] 메일 발송 실패: email={}", targetEmail.toMaskedValue(), e);
             throw new EmailSendException("메일 전송 중 오류가 발생했습니다.", e);
         }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -27,17 +27,6 @@ spring:
 
     open-in-view: false
 
-  mail:
-    host: smtp.gmail.com
-    port: 587
-    username: ${GMAIL_USERNAME}
-    password: ${GMAIL_PASSWORD}
-    properties:
-      mail:
-        smtp:
-          starttls:
-            enable: true
-          auth: true
 
 server:
   tomcat:

--- a/src/test/java/com/recyclestudy/email/EmailSenderTest.java
+++ b/src/test/java/com/recyclestudy/email/EmailSenderTest.java
@@ -2,28 +2,26 @@ package com.recyclestudy.email;
 
 import com.recyclestudy.exception.EmailSendException;
 import com.recyclestudy.member.domain.Email;
-import jakarta.mail.MessagingException;
-import jakarta.mail.internet.MimeMessage;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.mail.javamail.JavaMailSender;
+import software.amazon.awssdk.services.sesv2.SesV2Client;
+import software.amazon.awssdk.services.sesv2.model.SendEmailRequest;
+import software.amazon.awssdk.services.sesv2.model.SesV2Exception;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class EmailSenderTest {
 
     @Mock
-    private JavaMailSender javaMailSender;
+    private SesV2Client sesV2Client;
 
     @InjectMocks
     private EmailSender emailSender;
@@ -35,30 +33,24 @@ class EmailSenderTest {
         final Email targetEmail = Email.from("test@test.com");
         final String subject = "테스트 제목";
         final String content = "<html>테스트 내용</html>";
-        final MimeMessage mimeMessage = mock(MimeMessage.class);
-
-        given(javaMailSender.createMimeMessage()).willReturn(mimeMessage);
 
         // when
         emailSender.send(targetEmail, subject, content);
 
         // then
-        verify(javaMailSender).createMimeMessage();
-        verify(javaMailSender).send(mimeMessage);
+        verify(sesV2Client).sendEmail(any(SendEmailRequest.class));
     }
 
     @Test
     @DisplayName("메일 발송 실패 시 EmailSendException을 던진다")
-    void send_fail_throwsException() throws MessagingException {
+    void send_fail_throwsException() {
         // given
         final Email targetEmail = Email.from("test@test.com");
         final String subject = "테스트 제목";
         final String content = "<html>테스트 내용</html>";
-        final MimeMessage mimeMessage = mock(MimeMessage.class);
 
-        given(javaMailSender.createMimeMessage()).willReturn(mimeMessage);
-        willThrow(new MessagingException("메일 서버 오류"))
-                .given(mimeMessage).setRecipient(any(), any());
+        willThrow(SesV2Exception.builder().message("SES 오류").build())
+                .given(sesV2Client).sendEmail(any(SendEmailRequest.class));
 
         // when & then
         assertThatThrownBy(() -> emailSender.send(targetEmail, subject, content))

--- a/src/test/java/com/recyclestudy/email/EmailSenderTest.java
+++ b/src/test/java/com/recyclestudy/email/EmailSenderTest.java
@@ -2,12 +2,15 @@ package com.recyclestudy.email;
 
 import com.recyclestudy.exception.EmailSendException;
 import com.recyclestudy.member.domain.Email;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.sesv2.SesV2Client;
 import software.amazon.awssdk.services.sesv2.model.SendEmailRequest;
 import software.amazon.awssdk.services.sesv2.model.SesV2Exception;
@@ -38,7 +41,14 @@ class EmailSenderTest {
         emailSender.send(targetEmail, subject, content);
 
         // then
-        verify(sesV2Client).sendEmail(any(SendEmailRequest.class));
+        ArgumentCaptor<SendEmailRequest> captor = ArgumentCaptor.forClass(SendEmailRequest.class);
+        verify(sesV2Client).sendEmail(captor.capture());
+        SendEmailRequest request = captor.getValue();
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(request.fromEmailAddress()).isEqualTo("noreply@recycle-study.site");
+            softly.assertThat(request.destination().toAddresses()).containsExactly("test@test.com");
+            softly.assertThat(request.content().simple().subject().data()).isEqualTo(subject);
+        });
     }
 
     @Test
@@ -52,7 +62,26 @@ class EmailSenderTest {
         willThrow(SesV2Exception.builder().message("SES 오류").build())
                 .given(sesV2Client).sendEmail(any(SendEmailRequest.class));
 
-        // when & then
+        // when
+        // then
+        assertThatThrownBy(() -> emailSender.send(targetEmail, subject, content))
+                .isInstanceOf(EmailSendException.class)
+                .hasMessage("메일 전송 중 오류가 발생했습니다.");
+    }
+
+    @Test
+    @DisplayName("네트워크 오류 시 EmailSendException을 던진다")
+    void send_fail_networkError_throwsEmailSendException() {
+        // given
+        final Email targetEmail = Email.from("test@test.com");
+        final String subject = "테스트 제목";
+        final String content = "<html>테스트 내용</html>";
+
+        willThrow(SdkClientException.create("네트워크 오류"))
+                .given(sesV2Client).sendEmail(any(SendEmailRequest.class));
+
+        // when
+        // then
         assertThatThrownBy(() -> emailSender.send(targetEmail, subject, content))
                 .isInstanceOf(EmailSendException.class)
                 .hasMessage("메일 전송 중 오류가 발생했습니다.");


### PR DESCRIPTION
<!-- PR 템플릿 -->

## 🚀 작업 내용

### Gmail SMTP → AWS SES SDK v2 전환

기존 `spring-boot-starter-mail` + Gmail SMTP 방식을 `software.amazon.awssdk:sesv2` 직접 호출 방식으로 교체.

### **변경 이유**
- Gmail 개인 계정 의존성 제거
- IAM Role 기반 인증으로 크레덴셜 관리 불필요 (운영: EC2 인스턴스 프로파일, 로컬: ~/.aws/credentials)
- SES API 방식은 SMTP보다 처리량 및 에러 핸들링이 명확

### **AWS 인프라 설정**
- SES 도메인 검증: `recycle-study.site` (가비아 DNS CNAME 3개)
- IAM Role `RecycleStudyEC2Role` → EC2 인스턴스 프로파일 연결
- IAM 정책 `RecycleStudySESSendPolicy`: `ses:SendEmail`, `ses:SendRawEmail` (resource: `identity/*`)
- SES Production access 승인 완료

## 📸 이슈 번호

- close #80 

## ✍ 궁금한 점

- X