### PR TITLE
이메일 재전송 포기 기준을 maxRetry 횟수 -> deadline 기반으로 전환

### DIFF
--- a/src/main/java/com/recyclestudy/email/EmailRetryScheduler.java
+++ b/src/main/java/com/recyclestudy/email/EmailRetryScheduler.java
@@ -10,7 +10,7 @@ public class EmailRetryScheduler {
 
     private final EmailRetryService emailRetryService;
 
-    @Scheduled(fixedDelay = 60_000)
+    @Scheduled(fixedDelay = 300_000)
     public void runRetry() {
         emailRetryService.retryFailedEmails();
     }

--- a/src/main/java/com/recyclestudy/email/EmailRetryService.java
+++ b/src/main/java/com/recyclestudy/email/EmailRetryService.java
@@ -21,19 +21,15 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class EmailRetryService {
 
-    // 단기 주기(1일 미만) 재시도 제외: review_cycle에 주기 컬럼이 없으므로 scheduledAt 경과 시간으로 단기/장기 여부를 역산
-    private static final long SHORT_CYCLE_THRESHOLD_DAYS = 1;
-    private static final int MAX_RETRY_COUNT = 3;
-
     private final ReviewCycleRepository reviewCycleRepository;
     private final SingleReviewEmailSender singleReviewEmailSender;
     private final Clock clock;
 
     @Transactional(readOnly = true)
     public void retryFailedEmails() {
-        final LocalDateTime cutoffDateTime = LocalDateTime.now(clock).minusDays(SHORT_CYCLE_THRESHOLD_DAYS);
+        final LocalDateTime now = LocalDateTime.now(clock);
         final List<ReviewCycle> failedCycles = reviewCycleRepository.findAllRetryableCycles(
-                NotificationStatus.FAILED, MAX_RETRY_COUNT, cutoffDateTime);
+                NotificationStatus.FAILED, now);
 
         if (failedCycles.isEmpty()) {
             return;

--- a/src/main/java/com/recyclestudy/review/domain/NotificationHistory.java
+++ b/src/main/java/com/recyclestudy/review/domain/NotificationHistory.java
@@ -39,12 +39,15 @@ public class NotificationHistory extends BaseEntity {
     @Column(name = "last_attempted_at")
     private LocalDateTime lastAttemptedAt;
 
+    @Column(name = "deadline")
+    private LocalDateTime deadline;
+
     public static NotificationHistory withoutId(
             final ReviewCycle reviewCycle,
             final NotificationStatus status
     ) {
         validateNotNull(reviewCycle, status);
-        return new NotificationHistory(reviewCycle, status, 0, null);
+        return new NotificationHistory(reviewCycle, status, 0, null, null);
     }
 
     private static void validateNotNull(

--- a/src/main/java/com/recyclestudy/review/repository/NotificationHistoryRepository.java
+++ b/src/main/java/com/recyclestudy/review/repository/NotificationHistoryRepository.java
@@ -26,13 +26,15 @@ public interface NotificationHistoryRepository extends JpaRepository<Notificatio
     @Modifying(clearAutomatically = true)
     @Query("""
             UPDATE NotificationHistory nh
-            SET nh.status = :status, nh.failCount = nh.failCount + 1, nh.lastAttemptedAt = :now
-            WHERE nh.reviewCycle.id IN :reviewCycleIds
+            SET nh.status = :status, nh.failCount = nh.failCount + 1,
+                nh.lastAttemptedAt = :now, nh.deadline = :deadline
+            WHERE nh.reviewCycle.id = :reviewCycleId
             """)
     int updateStatusWithIncrementFailCount(
-            @Param("reviewCycleIds") List<Long> reviewCycleIds,
+            @Param("reviewCycleId") Long reviewCycleId,
             @Param("status") NotificationStatus status,
-            @Param("now") LocalDateTime now
+            @Param("now") LocalDateTime now,
+            @Param("deadline") LocalDateTime deadline
     );
 
     @Query("""

--- a/src/main/java/com/recyclestudy/review/repository/ReviewCycleRepository.java
+++ b/src/main/java/com/recyclestudy/review/repository/ReviewCycleRepository.java
@@ -4,9 +4,11 @@ import com.recyclestudy.review.domain.NotificationStatus;
 import com.recyclestudy.review.domain.ReviewCycle;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
 
 public interface ReviewCycleRepository extends JpaRepository<ReviewCycle, Long> {
 
@@ -29,12 +31,15 @@ public interface ReviewCycleRepository extends JpaRepository<ReviewCycle, Long> 
             JOIN FETCH r.member
             JOIN NotificationHistory nh ON rc.id = nh.reviewCycle.id
             WHERE nh.status = :status
-            AND nh.failCount < :maxRetryCount
-            AND rc.scheduledAt <= :cutoffDateTime
+            AND nh.deadline > :now
             """)
     List<ReviewCycle> findAllRetryableCycles(
             @Param("status") NotificationStatus status,
-            @Param("maxRetryCount") int maxRetryCount,
-            @Param("cutoffDateTime") LocalDateTime cutoffDateTime
+            @Param("now") LocalDateTime now
+    );
+
+    Optional<ReviewCycle> findFirstByReview_IdAndScheduledAtGreaterThanOrderByScheduledAtAsc(
+            Long reviewId,
+            LocalDateTime currentScheduledAt
     );
 }

--- a/src/main/java/com/recyclestudy/review/service/NotificationHistoryService.java
+++ b/src/main/java/com/recyclestudy/review/service/NotificationHistoryService.java
@@ -1,7 +1,9 @@
 package com.recyclestudy.review.service;
 
 import com.recyclestudy.review.domain.NotificationStatus;
+import com.recyclestudy.review.domain.ReviewCycle;
 import com.recyclestudy.review.repository.NotificationHistoryRepository;
+import com.recyclestudy.review.repository.ReviewCycleRepository;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -15,7 +17,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class NotificationHistoryService {
 
+    private static final long LAST_CYCLE_DEADLINE_HOURS = 24;
+
     private final NotificationHistoryRepository notificationHistoryRepository;
+    private final ReviewCycleRepository reviewCycleRepository;
     private final Clock clock;
 
     @Transactional
@@ -26,14 +31,29 @@ public class NotificationHistoryService {
         final LocalDateTime now = LocalDateTime.now(clock);
         int updated;
         if (status == NotificationStatus.FAILED) {
-            updated = notificationHistoryRepository.updateStatusWithIncrementFailCount(reviewCycleIds, status, now);
+            updated = updateToFailed(reviewCycleIds, now);
         } else {
             updated = notificationHistoryRepository.updateStatus(reviewCycleIds, status, now);
         }
         if (updated != reviewCycleIds.size()) {
             log.warn("[NOTIFY_HIST_MISMATCH] 기대={}, 실제={}", reviewCycleIds.size(), updated);
         }
-
         log.info("[NOTIFY_HIST_UPDATED] 알림 이력 상태 변경: status={}, count={}", status, updated);
+    }
+
+    private int updateToFailed(final List<Long> reviewCycleIds, final LocalDateTime now) {
+        int updated = 0;
+        for (final Long reviewCycleId : reviewCycleIds) {
+            final ReviewCycle reviewCycle = reviewCycleRepository.findById(reviewCycleId)
+                    .orElseThrow(() -> new IllegalStateException("ReviewCycle을 찾을 수 없습니다: " + reviewCycleId));
+            final LocalDateTime deadline = reviewCycleRepository
+                    .findFirstByReview_IdAndScheduledAtGreaterThanOrderByScheduledAtAsc(
+                            reviewCycle.getReview().getId(), reviewCycle.getScheduledAt())
+                    .map(ReviewCycle::getScheduledAt)
+                    .orElse(reviewCycle.getScheduledAt().plusHours(LAST_CYCLE_DEADLINE_HOURS));
+            updated += notificationHistoryRepository.updateStatusWithIncrementFailCount(
+                    reviewCycleId, NotificationStatus.FAILED, now, deadline);
+        }
+        return updated;
     }
 }

--- a/src/main/resources/db/migration/V20260307_1__add_deadline_to_notification_history.sql
+++ b/src/main/resources/db/migration/V20260307_1__add_deadline_to_notification_history.sql
@@ -1,0 +1,2 @@
+ALTER TABLE notification_history
+    ADD COLUMN deadline DATETIME NULL;

--- a/src/test/java/com/recyclestudy/email/EmailRetryServiceTest.java
+++ b/src/test/java/com/recyclestudy/email/EmailRetryServiceTest.java
@@ -51,7 +51,7 @@ class EmailRetryServiceTest {
         given(clock.instant()).willReturn(Instant.parse("2026-01-01T00:00:00Z"));
         given(clock.getZone()).willReturn(ZoneId.of("UTC"));
         given(reviewCycleRepository.findAllRetryableCycles(
-                eq(NotificationStatus.FAILED), any(Integer.class), any(LocalDateTime.class)))
+                eq(NotificationStatus.FAILED), any(LocalDateTime.class)))
                 .willReturn(Collections.emptyList());
 
         // when
@@ -85,7 +85,7 @@ class EmailRetryServiceTest {
         given(cycle2.getReview()).willReturn(review1);
 
         given(reviewCycleRepository.findAllRetryableCycles(
-                eq(NotificationStatus.FAILED), any(Integer.class), any(LocalDateTime.class)))
+                eq(NotificationStatus.FAILED), any(LocalDateTime.class)))
                 .willReturn(List.of(cycle1, cycle2));
 
         // when

--- a/src/test/java/com/recyclestudy/review/repository/ReviewCycleRepositoryTest.java
+++ b/src/test/java/com/recyclestudy/review/repository/ReviewCycleRepositoryTest.java
@@ -33,7 +33,7 @@ class ReviewCycleRepositoryTest {
     @Autowired
     private ReviewRepository reviewRepository;
 
-    private static final LocalDateTime NOW = LocalDateTime.now();
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 1, 1, 0, 0, 0);
     private static final LocalDateTime FUTURE_DEADLINE = NOW.plusHours(23);
     private static final LocalDateTime PAST_DEADLINE = NOW.minusHours(1);
     private static final LocalDateTime SCHEDULED_AT = NOW.minusDays(1);

--- a/src/test/java/com/recyclestudy/review/repository/ReviewCycleRepositoryTest.java
+++ b/src/test/java/com/recyclestudy/review/repository/ReviewCycleRepositoryTest.java
@@ -10,6 +10,7 @@ import com.recyclestudy.review.domain.ReviewCycle;
 import com.recyclestudy.review.domain.ReviewURL;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,23 +33,23 @@ class ReviewCycleRepositoryTest {
     @Autowired
     private ReviewRepository reviewRepository;
 
-    private static final LocalDateTime CUTOFF = LocalDateTime.now().minusDays(1);
-    private static final LocalDateTime LONG_AGO = LocalDateTime.now().minusDays(2);
-    private static final LocalDateTime RECENT = LocalDateTime.now().minusHours(1);
+    private static final LocalDateTime NOW = LocalDateTime.now();
+    private static final LocalDateTime FUTURE_DEADLINE = NOW.plusHours(23);
+    private static final LocalDateTime PAST_DEADLINE = NOW.minusHours(1);
+    private static final LocalDateTime SCHEDULED_AT = NOW.minusDays(1);
 
     @Test
-    @DisplayName("FAILED 상태이고 failCount가 최대 횟수 미만이면 재시도 대상에 포함된다")
+    @DisplayName("FAILED 상태이고 deadline이 현재보다 미래이면 재시도 대상에 포함된다")
     void findAllRetryableCycles_success() {
         // given
-        final ReviewCycle cycle = saveCycle("retry@email.com", LONG_AGO);
+        final ReviewCycle cycle = saveCycle("retry@email.com", SCHEDULED_AT);
         notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.PENDING));
-
         notificationHistoryRepository.updateStatusWithIncrementFailCount(
-                List.of(cycle.getId()), NotificationStatus.FAILED, LocalDateTime.now());
+                cycle.getId(), NotificationStatus.FAILED, NOW, FUTURE_DEADLINE);
 
         // when
         final List<ReviewCycle> results = reviewCycleRepository.findAllRetryableCycles(
-                NotificationStatus.FAILED, 3, CUTOFF);
+                NotificationStatus.FAILED, NOW);
 
         // then
         assertThat(results).hasSize(1);
@@ -59,12 +60,12 @@ class ReviewCycleRepositoryTest {
     @DisplayName("PENDING 상태만 있는 경우는 재시도 대상이 아니다")
     void findAllRetryableCycles_pendingOnly() {
         // given
-        final ReviewCycle cycle = saveCycle("pending@email.com", LONG_AGO);
+        final ReviewCycle cycle = saveCycle("pending@email.com", SCHEDULED_AT);
         notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.PENDING));
 
         // when
         final List<ReviewCycle> results = reviewCycleRepository.findAllRetryableCycles(
-                NotificationStatus.FAILED, 3, CUTOFF);
+                NotificationStatus.FAILED, NOW);
 
         // then
         assertThat(results).isEmpty();
@@ -74,36 +75,31 @@ class ReviewCycleRepositoryTest {
     @DisplayName("이미 SENT 상태이면 재시도 대상이 아니다")
     void findAllRetryableCycles_alreadySent() {
         // given
-        final ReviewCycle cycle = saveCycle("sent@email.com", LONG_AGO);
+        final ReviewCycle cycle = saveCycle("sent@email.com", SCHEDULED_AT);
         notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.PENDING));
-
         notificationHistoryRepository.updateStatus(
-                List.of(cycle.getId()), NotificationStatus.SENT, LocalDateTime.now());
+                List.of(cycle.getId()), NotificationStatus.SENT, NOW);
 
         // when
         final List<ReviewCycle> results = reviewCycleRepository.findAllRetryableCycles(
-                NotificationStatus.FAILED, 3, CUTOFF);
+                NotificationStatus.FAILED, NOW);
 
         // then
         assertThat(results).isEmpty();
     }
 
     @Test
-    @DisplayName("failCount가 최대 재시도 횟수에 도달하면 재시도 대상이 아니다")
-    void findAllRetryableCycles_maxRetryReached() {
+    @DisplayName("deadline이 현재보다 과거이면 재시도 대상이 아니다")
+    void findAllRetryableCycles_deadlineExpired() {
         // given
-        final ReviewCycle cycle = saveCycle("max@email.com", LONG_AGO);
+        final ReviewCycle cycle = saveCycle("expired@email.com", SCHEDULED_AT);
         notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.PENDING));
-
-        // failCount를 3으로 만들기 위해 3번 increment
-        for (int i = 0; i < 3; i++) {
-            notificationHistoryRepository.updateStatusWithIncrementFailCount(
-                    List.of(cycle.getId()), NotificationStatus.FAILED, LocalDateTime.now());
-        }
+        notificationHistoryRepository.updateStatusWithIncrementFailCount(
+                cycle.getId(), NotificationStatus.FAILED, NOW, PAST_DEADLINE);
 
         // when
         final List<ReviewCycle> results = reviewCycleRepository.findAllRetryableCycles(
-                NotificationStatus.FAILED, 3, CUTOFF);
+                NotificationStatus.FAILED, NOW);
 
         // then
         assertThat(results).isEmpty();
@@ -113,32 +109,71 @@ class ReviewCycleRepositoryTest {
     @DisplayName("notification_history가 없는 경우 재시도 대상이 아니다")
     void findAllRetryableCycles_noHistory() {
         // given
-        saveCycle("new@email.com", LONG_AGO);
+        saveCycle("new@email.com", SCHEDULED_AT);
 
         // when
         final List<ReviewCycle> results = reviewCycleRepository.findAllRetryableCycles(
-                NotificationStatus.FAILED, 3, CUTOFF);
+                NotificationStatus.FAILED, NOW);
 
         // then
         assertThat(results).isEmpty();
     }
 
     @Test
-    @DisplayName("scheduledAt이 cutoffDateTime보다 최근인 단기 주기는 재시도 대상이 아니다")
-    void findAllRetryableCycles_shortCycle() {
+    @DisplayName("failCount가 아무리 높아도 deadline이 미래이면 재시도 대상에 포함된다")
+    void findAllRetryableCycles_failCountDoesNotAffectEligibility() {
         // given
-        final ReviewCycle cycle = saveCycle("short@email.com", RECENT);
+        final ReviewCycle cycle = saveCycle("many-fails@email.com", SCHEDULED_AT);
         notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.PENDING));
-
-        notificationHistoryRepository.updateStatusWithIncrementFailCount(
-                List.of(cycle.getId()), NotificationStatus.FAILED, LocalDateTime.now());
+        // failCount를 10으로 설정해도 deadline이 미래이면 재시도 대상
+        for (int i = 0; i < 10; i++) {
+            notificationHistoryRepository.updateStatusWithIncrementFailCount(
+                    cycle.getId(), NotificationStatus.FAILED, NOW, FUTURE_DEADLINE);
+        }
 
         // when
         final List<ReviewCycle> results = reviewCycleRepository.findAllRetryableCycles(
-                NotificationStatus.FAILED, 3, CUTOFF);
+                NotificationStatus.FAILED, NOW);
 
         // then
-        assertThat(results).isEmpty();
+        assertThat(results).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("다음 주기가 있으면 scheduledAt이 가장 가까운 ReviewCycle을 반환한다")
+    void findNextScheduledAt_success() {
+        // given
+        final Member member = memberRepository.save(Member.withoutId(Email.from("next@email.com")));
+        final Review review = reviewRepository.save(Review.withoutId(member, ReviewURL.from("url")));
+        final ReviewCycle current = reviewCycleRepository.save(ReviewCycle.withoutId(review, NOW.plusHours(1)));
+        final ReviewCycle next = reviewCycleRepository.save(ReviewCycle.withoutId(review, NOW.plusDays(1)));
+        reviewCycleRepository.save(ReviewCycle.withoutId(review, NOW.plusDays(7)));
+
+        // when
+        final Optional<ReviewCycle> result = reviewCycleRepository
+                .findFirstByReview_IdAndScheduledAtGreaterThanOrderByScheduledAtAsc(
+                        review.getId(), current.getScheduledAt());
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().getId()).isEqualTo(next.getId());
+    }
+
+    @Test
+    @DisplayName("마지막 주기이면 Optional.empty()를 반환한다")
+    void findNextScheduledAt_lastCycle() {
+        // given
+        final Member member = memberRepository.save(Member.withoutId(Email.from("last@email.com")));
+        final Review review = reviewRepository.save(Review.withoutId(member, ReviewURL.from("url")));
+        final ReviewCycle last = reviewCycleRepository.save(ReviewCycle.withoutId(review, NOW.plusDays(30)));
+
+        // when
+        final Optional<ReviewCycle> result = reviewCycleRepository
+                .findFirstByReview_IdAndScheduledAtGreaterThanOrderByScheduledAtAsc(
+                        review.getId(), last.getScheduledAt());
+
+        // then
+        assertThat(result).isEmpty();
     }
 
     private ReviewCycle saveCycle(final String email, final LocalDateTime scheduledAt) {

--- a/src/test/java/com/recyclestudy/review/service/NotificationHistoryServiceTest.java
+++ b/src/test/java/com/recyclestudy/review/service/NotificationHistoryServiceTest.java
@@ -1,12 +1,16 @@
 package com.recyclestudy.review.service;
 
 import com.recyclestudy.review.domain.NotificationStatus;
+import com.recyclestudy.review.domain.Review;
+import com.recyclestudy.review.domain.ReviewCycle;
 import com.recyclestudy.review.repository.NotificationHistoryRepository;
+import com.recyclestudy.review.repository.ReviewCycleRepository;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,6 +21,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -24,6 +29,9 @@ class NotificationHistoryServiceTest {
 
     @Mock
     NotificationHistoryRepository notificationHistoryRepository;
+
+    @Mock
+    ReviewCycleRepository reviewCycleRepository;
 
     @Mock
     Clock clock;
@@ -50,20 +58,67 @@ class NotificationHistoryServiceTest {
     }
 
     @Test
-    @DisplayName("FAILED 상태로 업데이트하면 failCount를 1 증가시킨다")
+    @DisplayName("FAILED 상태로 업데이트하면 deadline과 함께 failCount를 1 증가시킨다")
     void updateStatus_failed() {
         // given
-        final List<Long> reviewCycleIds = List.of(1L);
-        BDDMockito.given(clock.instant())
-                .willReturn(Instant.parse("2026-01-01T00:00:00Z"));
-        BDDMockito.given(clock.getZone())
-                .willReturn(ZoneId.of("UTC"));
+        final Long reviewCycleId = 1L;
+        final LocalDateTime scheduledAt = LocalDateTime.of(2026, 1, 1, 10, 0);
+        final LocalDateTime nextScheduledAt = LocalDateTime.of(2026, 1, 2, 10, 0);
+
+        final Review review = mock(Review.class);
+        BDDMockito.given(review.getId()).willReturn(100L);
+
+        final ReviewCycle reviewCycle = mock(ReviewCycle.class);
+        BDDMockito.given(reviewCycle.getReview()).willReturn(review);
+        BDDMockito.given(reviewCycle.getScheduledAt()).willReturn(scheduledAt);
+
+        BDDMockito.given(clock.instant()).willReturn(Instant.parse("2026-01-01T00:00:00Z"));
+        BDDMockito.given(clock.getZone()).willReturn(ZoneId.of("UTC"));
+        final ReviewCycle nextReviewCycle = mock(ReviewCycle.class);
+        BDDMockito.given(nextReviewCycle.getScheduledAt()).willReturn(nextScheduledAt);
+
+        BDDMockito.given(reviewCycleRepository.findById(reviewCycleId))
+                .willReturn(Optional.of(reviewCycle));
+        BDDMockito.given(reviewCycleRepository
+                .findFirstByReview_IdAndScheduledAtGreaterThanOrderByScheduledAtAsc(review.getId(), scheduledAt))
+                .willReturn(Optional.of(nextReviewCycle));
 
         // when
-        notificationHistoryService.updateStatus(reviewCycleIds, NotificationStatus.FAILED);
+        notificationHistoryService.updateStatus(List.of(reviewCycleId), NotificationStatus.FAILED);
 
         // then
         verify(notificationHistoryRepository).updateStatusWithIncrementFailCount(
-                eq(reviewCycleIds), eq(NotificationStatus.FAILED), any(LocalDateTime.class));
+                eq(reviewCycleId), eq(NotificationStatus.FAILED), any(LocalDateTime.class), eq(nextScheduledAt));
+    }
+
+    @Test
+    @DisplayName("마지막 주기이면 deadline을 scheduledAt + 24h로 설정한다")
+    void updateStatus_failed_lastCycle() {
+        // given
+        final Long reviewCycleId = 1L;
+        final LocalDateTime scheduledAt = LocalDateTime.of(2026, 1, 30, 10, 0);
+        final LocalDateTime expectedDeadline = scheduledAt.plusHours(24);
+
+        final Review review = mock(Review.class);
+        BDDMockito.given(review.getId()).willReturn(100L);
+
+        final ReviewCycle reviewCycle = mock(ReviewCycle.class);
+        BDDMockito.given(reviewCycle.getReview()).willReturn(review);
+        BDDMockito.given(reviewCycle.getScheduledAt()).willReturn(scheduledAt);
+
+        BDDMockito.given(clock.instant()).willReturn(Instant.parse("2026-01-30T00:00:00Z"));
+        BDDMockito.given(clock.getZone()).willReturn(ZoneId.of("UTC"));
+        BDDMockito.given(reviewCycleRepository.findById(reviewCycleId))
+                .willReturn(Optional.of(reviewCycle));
+        BDDMockito.given(reviewCycleRepository
+                .findFirstByReview_IdAndScheduledAtGreaterThanOrderByScheduledAtAsc(review.getId(), scheduledAt))
+                .willReturn(Optional.empty());
+
+        // when
+        notificationHistoryService.updateStatus(List.of(reviewCycleId), NotificationStatus.FAILED);
+
+        // then
+        verify(notificationHistoryRepository).updateStatusWithIncrementFailCount(
+                eq(reviewCycleId), eq(NotificationStatus.FAILED), any(LocalDateTime.class), eq(expectedDeadline));
     }
 }


### PR DESCRIPTION
## 🚀 작업 내용

이메일 재전송 포기 기준을 `maxRetry=N` 횟수 방식에서 `deadline` 기반 방식으로 전환

### 변경 배경

폴링 주기 5분 * `maxRetry=3` = 재시도 유효 시간 15분으로, SES 최소 장애 지속 시간(~3시간)보다 훨씬 짧아 재전송 기능이 사실상 동작하지 않는 문제가 존재.

포기 기준을 `fail_count` 상한에서 허용 윈도우(다음 복습 주기 이전) 기반 `deadline`으로 전환하여, SES가 복구되는 순간 자연스럽게 재전송이 성공하는 구조로 변경.

### 변경 내용

### 설계 요약 (deadline 기반 보장값)

| 항목 | 일반적 maxRetry=3 방식 | 이 설계 (deadline 기반) |
|---|---|---|
| 재시도 유효 시간 (1시간 주기) | 15분 (5분 * 3회) | ~23시간 (허용 윈도우) |
| SES 3시간 장애 후 복구 가능 여부 | 불가 (15분 만에 포기) | 가능 |
| SES 16시간 장애 후 복구 가능 여부 | 불가 | 가능 |
| SES 복구 후 재전송 최대 지연 | — (이미 포기) | 5분 (폴링 주기) |

## 📸 이슈 번호

- close #83 

## ✍ 궁금한 점

- `updateToFailed`는 cycleId별로 개별 쿼리를 실행하고 있음. 현재 규모에서는 문제없지만 건수가 커지면 배치 처리 방식 전환이 필요할 수 있음
