### PR TITLE
notification_history.review_cycle_id unique constraint 추가

### DIFF
--- a/src/main/java/com/recyclestudy/review/domain/NotificationHistory.java
+++ b/src/main/java/com/recyclestudy/review/domain/NotificationHistory.java
@@ -10,6 +10,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -18,7 +19,7 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.FieldNameConstants;
 
 @Entity
-@Table(name = "notification_history")
+@Table(name = "notification_history", uniqueConstraints = @UniqueConstraint(columnNames = "review_cycle_id"))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @FieldNameConstants(level = AccessLevel.PRIVATE)

--- a/src/main/java/com/recyclestudy/review/domain/NotificationHistory.java
+++ b/src/main/java/com/recyclestudy/review/domain/NotificationHistory.java
@@ -19,7 +19,10 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.FieldNameConstants;
 
 @Entity
-@Table(name = "notification_history", uniqueConstraints = @UniqueConstraint(columnNames = "review_cycle_id"))
+@Table(
+        name = "notification_history",
+        uniqueConstraints = @UniqueConstraint(name = "uk_notification_history_review_cycle_id", columnNames = "review_cycle_id")
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @FieldNameConstants(level = AccessLevel.PRIVATE)

--- a/src/main/java/com/recyclestudy/review/domain/NotificationHistory.java
+++ b/src/main/java/com/recyclestudy/review/domain/NotificationHistory.java
@@ -21,7 +21,10 @@ import lombok.experimental.FieldNameConstants;
 @Entity
 @Table(
         name = "notification_history",
-        uniqueConstraints = @UniqueConstraint(name = "uk_notification_history_review_cycle_id", columnNames = "review_cycle_id")
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_notification_history_review_cycle_id",
+                columnNames = "review_cycle_id"
+        )
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/main/resources/db/migration/V20260307_2__add_unique_constraint_to_notification_history.sql
+++ b/src/main/resources/db/migration/V20260307_2__add_unique_constraint_to_notification_history.sql
@@ -1,0 +1,2 @@
+ALTER TABLE notification_history
+    ADD CONSTRAINT uk_notification_history_review_cycle_id UNIQUE (review_cycle_id);


### PR DESCRIPTION
<!-- PR 템플릿 -->

## 🚀 작업 내용

### **V20260307_2__add_unique_constraint_to_notification_history.sql**
- `notification_history` 테이블의 `review_cycle_id` 컬럼에 유니크 제약 조건 추가
- 제약 조건명: `uk_notification_history_review_cycle_id`

### **NotificationHistory.java**
- `@Table` 어노테이션에 `uniqueConstraints = @UniqueConstraint(columnNames = "review_cycle_id")` 추가
- DB 스키마와 JPA 메타데이터를 일치시켜 `review_cycle_id` 당 레코드 1개 보장

## 📸 이슈 번호

- close #85 

## ✍ 궁금한 점

- X
