### PR TITLE
deadline을 PENDING 생성 시점에 결정하도록 NotificationHistory 설계 개선

### DIFF
--- a/src/main/java/com/recyclestudy/review/domain/NotificationHistory.java
+++ b/src/main/java/com/recyclestudy/review/domain/NotificationHistory.java
@@ -46,24 +46,27 @@ public class NotificationHistory extends BaseEntity {
     @Column(name = "last_attempted_at")
     private LocalDateTime lastAttemptedAt;
 
-    @Column(name = "deadline")
+    @Column(name = "deadline", nullable = false)
     private LocalDateTime deadline;
 
     public static NotificationHistory withoutId(
             final ReviewCycle reviewCycle,
-            final NotificationStatus status
+            final NotificationStatus status,
+            final LocalDateTime deadline
     ) {
-        validateNotNull(reviewCycle, status);
-        return new NotificationHistory(reviewCycle, status, 0, null, null);
+        validateNotNull(reviewCycle, status, deadline);
+        return new NotificationHistory(reviewCycle, status, 0, null, deadline);
     }
 
     private static void validateNotNull(
             final ReviewCycle reviewCycle,
-            final NotificationStatus status
+            final NotificationStatus status,
+            final LocalDateTime deadline
     ) {
         NullValidator.builder()
                 .add(Fields.reviewCycle, reviewCycle)
                 .add(Fields.status, status)
+                .add(Fields.deadline, deadline)
                 .validate();
     }
 }

--- a/src/main/java/com/recyclestudy/review/repository/NotificationHistoryRepository.java
+++ b/src/main/java/com/recyclestudy/review/repository/NotificationHistoryRepository.java
@@ -26,15 +26,13 @@ public interface NotificationHistoryRepository extends JpaRepository<Notificatio
     @Modifying(clearAutomatically = true)
     @Query("""
             UPDATE NotificationHistory nh
-            SET nh.status = :status, nh.failCount = nh.failCount + 1,
-                nh.lastAttemptedAt = :now, nh.deadline = :deadline
-            WHERE nh.reviewCycle.id = :reviewCycleId
+            SET nh.status = :status, nh.failCount = nh.failCount + 1, nh.lastAttemptedAt = :now
+            WHERE nh.reviewCycle.id IN :reviewCycleIds
             """)
-    int updateStatusWithIncrementFailCount(
-            @Param("reviewCycleId") Long reviewCycleId,
+    int updateStatusAndIncrementFailCount(
+            @Param("reviewCycleIds") List<Long> reviewCycleIds,
             @Param("status") NotificationStatus status,
-            @Param("now") LocalDateTime now,
-            @Param("deadline") LocalDateTime deadline
+            @Param("now") LocalDateTime now
     );
 
     @Query("""

--- a/src/main/java/com/recyclestudy/review/repository/ReviewCycleRepository.java
+++ b/src/main/java/com/recyclestudy/review/repository/ReviewCycleRepository.java
@@ -4,7 +4,6 @@ import com.recyclestudy.review.domain.NotificationStatus;
 import com.recyclestudy.review.domain.ReviewCycle;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -38,8 +37,4 @@ public interface ReviewCycleRepository extends JpaRepository<ReviewCycle, Long> 
             @Param("now") LocalDateTime now
     );
 
-    Optional<ReviewCycle> findFirstByReview_IdAndScheduledAtGreaterThanOrderByScheduledAtAsc(
-            Long reviewId,
-            LocalDateTime currentScheduledAt
-    );
 }

--- a/src/main/java/com/recyclestudy/review/service/NotificationHistoryService.java
+++ b/src/main/java/com/recyclestudy/review/service/NotificationHistoryService.java
@@ -1,9 +1,7 @@
 package com.recyclestudy.review.service;
 
 import com.recyclestudy.review.domain.NotificationStatus;
-import com.recyclestudy.review.domain.ReviewCycle;
 import com.recyclestudy.review.repository.NotificationHistoryRepository;
-import com.recyclestudy.review.repository.ReviewCycleRepository;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -17,10 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class NotificationHistoryService {
 
-    private static final long LAST_CYCLE_DEADLINE_HOURS = 24;
-
     private final NotificationHistoryRepository notificationHistoryRepository;
-    private final ReviewCycleRepository reviewCycleRepository;
     private final Clock clock;
 
     @Transactional
@@ -29,9 +24,9 @@ public class NotificationHistoryService {
             return;
         }
         final LocalDateTime now = LocalDateTime.now(clock);
-        int updated;
+        final int updated;
         if (status == NotificationStatus.FAILED) {
-            updated = updateToFailed(reviewCycleIds, now);
+            updated = notificationHistoryRepository.updateStatusAndIncrementFailCount(reviewCycleIds, status, now);
         } else {
             updated = notificationHistoryRepository.updateStatus(reviewCycleIds, status, now);
         }
@@ -39,21 +34,5 @@ public class NotificationHistoryService {
             log.warn("[NOTIFY_HIST_MISMATCH] 기대={}, 실제={}", reviewCycleIds.size(), updated);
         }
         log.info("[NOTIFY_HIST_UPDATED] 알림 이력 상태 변경: status={}, count={}", status, updated);
-    }
-
-    private int updateToFailed(final List<Long> reviewCycleIds, final LocalDateTime now) {
-        int updated = 0;
-        for (final Long reviewCycleId : reviewCycleIds) {
-            final ReviewCycle reviewCycle = reviewCycleRepository.findById(reviewCycleId)
-                    .orElseThrow(() -> new IllegalStateException("ReviewCycle을 찾을 수 없습니다: " + reviewCycleId));
-            final LocalDateTime deadline = reviewCycleRepository
-                    .findFirstByReview_IdAndScheduledAtGreaterThanOrderByScheduledAtAsc(
-                            reviewCycle.getReview().getId(), reviewCycle.getScheduledAt())
-                    .map(ReviewCycle::getScheduledAt)
-                    .orElse(reviewCycle.getScheduledAt().plusHours(LAST_CYCLE_DEADLINE_HOURS));
-            updated += notificationHistoryRepository.updateStatusWithIncrementFailCount(
-                    reviewCycleId, NotificationStatus.FAILED, now, deadline);
-        }
-        return updated;
     }
 }

--- a/src/main/java/com/recyclestudy/review/service/ReviewService.java
+++ b/src/main/java/com/recyclestudy/review/service/ReviewService.java
@@ -24,6 +24,7 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -33,6 +34,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Slf4j
 public class ReviewService {
+
+    private static final long LAST_CYCLE_DEADLINE_HOURS = 24;
 
     private final ReviewRepository reviewRepository;
     private final ReviewCycleRepository reviewCycleRepository;
@@ -96,8 +99,14 @@ public class ReviewService {
     }
 
     private void savePendingNotificationHistory(final List<ReviewCycle> savedReviewCycles) {
-        final List<NotificationHistory> notificationHistories = savedReviewCycles.stream()
-                .map(reviewCycle -> NotificationHistory.withoutId(reviewCycle, NotificationStatus.PENDING))
+        final List<NotificationHistory> notificationHistories = IntStream.range(0, savedReviewCycles.size())
+                .mapToObj(i -> {
+                    final ReviewCycle reviewCycle = savedReviewCycles.get(i);
+                    final LocalDateTime deadline = (i < savedReviewCycles.size() - 1)
+                            ? savedReviewCycles.get(i + 1).getScheduledAt()
+                            : reviewCycle.getScheduledAt().plusHours(LAST_CYCLE_DEADLINE_HOURS);
+                    return NotificationHistory.withoutId(reviewCycle, NotificationStatus.PENDING, deadline);
+                })
                 .toList();
         final List<NotificationHistory> savedNotificationHistories
                 = notificationHistoryRepository.saveAll(notificationHistories);

--- a/src/main/resources/db/migration/V20260308_1__change_deadline_not_null_in_notification_history.sql
+++ b/src/main/resources/db/migration/V20260308_1__change_deadline_not_null_in_notification_history.sql
@@ -1,0 +1,23 @@
+-- Step 1: 다음 주기가 있는 레코드 -> deadline = 다음 주기의 scheduled_at
+UPDATE notification_history nh
+    INNER JOIN review_cycle rc ON rc.id = nh.review_cycle_id
+    INNER JOIN (
+        SELECT rc1.id AS current_id, MIN(rc2.scheduled_at) AS next_scheduled_at
+        FROM review_cycle rc1
+            INNER JOIN review_cycle rc2
+                ON rc2.review_id = rc1.review_id
+                AND rc2.scheduled_at > rc1.scheduled_at
+        GROUP BY rc1.id
+    ) next ON next.current_id = rc.id
+SET nh.deadline = next.next_scheduled_at
+WHERE nh.deadline IS NULL;
+
+-- Step 2: 마지막 주기 -> deadline = scheduled_at + 24시간
+UPDATE notification_history nh
+    INNER JOIN review_cycle rc ON rc.id = nh.review_cycle_id
+SET nh.deadline = rc.scheduled_at + INTERVAL 24 HOUR
+WHERE nh.deadline IS NULL;
+
+-- Step 3: NOT NULL 제약 추가
+ALTER TABLE notification_history
+    MODIFY COLUMN deadline DATETIME NOT NULL;

--- a/src/test/java/com/recyclestudy/review/domain/NotificationHistoryTest.java
+++ b/src/test/java/com/recyclestudy/review/domain/NotificationHistoryTest.java
@@ -19,11 +19,13 @@ class NotificationHistoryTest {
     private static Stream<Arguments> provideInvalidValue() {
         final ReviewCycle reviewCycle = createReviewCycle();
         final NotificationStatus status = NotificationStatus.PENDING;
+        final LocalDateTime deadline = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES).plusHours(24);
 
         return Stream.of(
-                Arguments.of(null, status),
-                Arguments.of(reviewCycle, null),
-                Arguments.of(null, null)
+                Arguments.of(null, status, deadline),
+                Arguments.of(reviewCycle, null, deadline),
+                Arguments.of(reviewCycle, status, null),
+                Arguments.of(null, null, null)
         );
     }
 
@@ -40,14 +42,16 @@ class NotificationHistoryTest {
         // given
         final ReviewCycle reviewCycle = createReviewCycle();
         final NotificationStatus status = NotificationStatus.PENDING;
+        final LocalDateTime deadline = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES).plusHours(24);
 
         // when
-        final NotificationHistory actual = NotificationHistory.withoutId(reviewCycle, status);
+        final NotificationHistory actual = NotificationHistory.withoutId(reviewCycle, status, deadline);
 
         // then
         assertSoftly(softAssertions -> {
             softAssertions.assertThat(actual.getReviewCycle()).isEqualTo(reviewCycle);
             softAssertions.assertThat(actual.getStatus()).isEqualTo(status);
+            softAssertions.assertThat(actual.getDeadline()).isEqualTo(deadline);
         });
     }
 
@@ -56,12 +60,13 @@ class NotificationHistoryTest {
     @DisplayName("null로 생성 시도 시, 예외를 던진다")
     void throwExceptionWhenNull(
             final ReviewCycle reviewCycle,
-            final NotificationStatus status
+            final NotificationStatus status,
+            final LocalDateTime deadline
     ) {
         // given
         // when
         // then
-        assertThatThrownBy(() -> NotificationHistory.withoutId(reviewCycle, status))
+        assertThatThrownBy(() -> NotificationHistory.withoutId(reviewCycle, status, deadline))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/test/java/com/recyclestudy/review/repository/NotificationHistoryRepositoryTest.java
+++ b/src/test/java/com/recyclestudy/review/repository/NotificationHistoryRepositoryTest.java
@@ -41,8 +41,8 @@ class NotificationHistoryRepositoryTest {
     void findAllPendingByMember_AscOrderAndStatus() {
         // given
         final Member member = saveMember("user@test.com");
-        saveNh(member, T2, NotificationStatus.PENDING);
-        saveNh(member, T1, NotificationStatus.PENDING);
+        saveNotificationHistory(member, T2, NotificationStatus.PENDING);
+        saveNotificationHistory(member, T1, NotificationStatus.PENDING);
 
         // when
         final List<NotificationHistory> result = notificationHistoryRepository
@@ -62,8 +62,8 @@ class NotificationHistoryRepositoryTest {
         // given
         final Member member = saveMember("user@test.com");
         final Member other = saveMember("other@test.com");
-        saveNh(member, T1, NotificationStatus.PENDING);
-        saveNh(other, T1, NotificationStatus.PENDING);
+        saveNotificationHistory(member, T1, NotificationStatus.PENDING);
+        saveNotificationHistory(other, T1, NotificationStatus.PENDING);
 
         // when
         final List<NotificationHistory> result = notificationHistoryRepository
@@ -79,8 +79,8 @@ class NotificationHistoryRepositoryTest {
     void findAllPendingByMember_excludesNonAndStatus() {
         // given
         final Member member = saveMember("user@test.com");
-        saveNh(member, T1, NotificationStatus.SENT);
-        saveNh(member, T2, NotificationStatus.FAILED);
+        saveNotificationHistory(member, T1, NotificationStatus.SENT);
+        saveNotificationHistory(member, T2, NotificationStatus.FAILED);
 
         // when
         final List<NotificationHistory> result = notificationHistoryRepository
@@ -108,10 +108,11 @@ class NotificationHistoryRepositoryTest {
         return memberRepository.save(Member.withoutId(Email.from(email)));
     }
 
-    private NotificationHistory saveNh(final Member member, final LocalDateTime scheduledAt,
-                                       final NotificationStatus status) {
+    private NotificationHistory saveNotificationHistory(final Member member, final LocalDateTime scheduledAt,
+                                                        final NotificationStatus status) {
         final Review review = reviewRepository.save(Review.withoutId(member, ReviewURL.from("https://example.com")));
         final ReviewCycle cycle = reviewCycleRepository.save(ReviewCycle.withoutId(review, scheduledAt));
-        return notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, status));
+        return notificationHistoryRepository.save(
+                NotificationHistory.withoutId(cycle, status, scheduledAt.plusHours(24)));
     }
 }

--- a/src/test/java/com/recyclestudy/review/repository/ReviewCycleRepositoryTest.java
+++ b/src/test/java/com/recyclestudy/review/repository/ReviewCycleRepositoryTest.java
@@ -10,7 +10,6 @@ import com.recyclestudy.review.domain.ReviewCycle;
 import com.recyclestudy.review.domain.ReviewURL;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,9 +42,10 @@ class ReviewCycleRepositoryTest {
     void findAllRetryableCycles_success() {
         // given
         final ReviewCycle cycle = saveCycle("retry@email.com", SCHEDULED_AT);
-        notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.PENDING));
-        notificationHistoryRepository.updateStatusWithIncrementFailCount(
-                cycle.getId(), NotificationStatus.FAILED, NOW, FUTURE_DEADLINE);
+        notificationHistoryRepository.save(
+                NotificationHistory.withoutId(cycle, NotificationStatus.PENDING, FUTURE_DEADLINE));
+        notificationHistoryRepository.updateStatusAndIncrementFailCount(
+                List.of(cycle.getId()), NotificationStatus.FAILED, NOW);
 
         // when
         final List<ReviewCycle> results = reviewCycleRepository.findAllRetryableCycles(
@@ -61,7 +61,8 @@ class ReviewCycleRepositoryTest {
     void findAllRetryableCycles_pendingOnly() {
         // given
         final ReviewCycle cycle = saveCycle("pending@email.com", SCHEDULED_AT);
-        notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.PENDING));
+        notificationHistoryRepository.save(
+                NotificationHistory.withoutId(cycle, NotificationStatus.PENDING, FUTURE_DEADLINE));
 
         // when
         final List<ReviewCycle> results = reviewCycleRepository.findAllRetryableCycles(
@@ -76,7 +77,8 @@ class ReviewCycleRepositoryTest {
     void findAllRetryableCycles_alreadySent() {
         // given
         final ReviewCycle cycle = saveCycle("sent@email.com", SCHEDULED_AT);
-        notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.PENDING));
+        notificationHistoryRepository.save(
+                NotificationHistory.withoutId(cycle, NotificationStatus.PENDING, FUTURE_DEADLINE));
         notificationHistoryRepository.updateStatus(
                 List.of(cycle.getId()), NotificationStatus.SENT, NOW);
 
@@ -93,9 +95,10 @@ class ReviewCycleRepositoryTest {
     void findAllRetryableCycles_deadlineExpired() {
         // given
         final ReviewCycle cycle = saveCycle("expired@email.com", SCHEDULED_AT);
-        notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.PENDING));
-        notificationHistoryRepository.updateStatusWithIncrementFailCount(
-                cycle.getId(), NotificationStatus.FAILED, NOW, PAST_DEADLINE);
+        notificationHistoryRepository.save(
+                NotificationHistory.withoutId(cycle, NotificationStatus.PENDING, PAST_DEADLINE));
+        notificationHistoryRepository.updateStatusAndIncrementFailCount(
+                List.of(cycle.getId()), NotificationStatus.FAILED, NOW);
 
         // when
         final List<ReviewCycle> results = reviewCycleRepository.findAllRetryableCycles(
@@ -124,11 +127,12 @@ class ReviewCycleRepositoryTest {
     void findAllRetryableCycles_failCountDoesNotAffectEligibility() {
         // given
         final ReviewCycle cycle = saveCycle("many-fails@email.com", SCHEDULED_AT);
-        notificationHistoryRepository.save(NotificationHistory.withoutId(cycle, NotificationStatus.PENDING));
+        notificationHistoryRepository.save(
+                NotificationHistory.withoutId(cycle, NotificationStatus.PENDING, FUTURE_DEADLINE));
         // failCount를 10으로 설정해도 deadline이 미래이면 재시도 대상
         for (int i = 0; i < 10; i++) {
-            notificationHistoryRepository.updateStatusWithIncrementFailCount(
-                    cycle.getId(), NotificationStatus.FAILED, NOW, FUTURE_DEADLINE);
+            notificationHistoryRepository.updateStatusAndIncrementFailCount(
+                    List.of(cycle.getId()), NotificationStatus.FAILED, NOW);
         }
 
         // when
@@ -137,43 +141,6 @@ class ReviewCycleRepositoryTest {
 
         // then
         assertThat(results).hasSize(1);
-    }
-
-    @Test
-    @DisplayName("다음 주기가 있으면 scheduledAt이 가장 가까운 ReviewCycle을 반환한다")
-    void findNextScheduledAt_success() {
-        // given
-        final Member member = memberRepository.save(Member.withoutId(Email.from("next@email.com")));
-        final Review review = reviewRepository.save(Review.withoutId(member, ReviewURL.from("url")));
-        final ReviewCycle current = reviewCycleRepository.save(ReviewCycle.withoutId(review, NOW.plusHours(1)));
-        final ReviewCycle next = reviewCycleRepository.save(ReviewCycle.withoutId(review, NOW.plusDays(1)));
-        reviewCycleRepository.save(ReviewCycle.withoutId(review, NOW.plusDays(7)));
-
-        // when
-        final Optional<ReviewCycle> result = reviewCycleRepository
-                .findFirstByReview_IdAndScheduledAtGreaterThanOrderByScheduledAtAsc(
-                        review.getId(), current.getScheduledAt());
-
-        // then
-        assertThat(result).isPresent();
-        assertThat(result.get().getId()).isEqualTo(next.getId());
-    }
-
-    @Test
-    @DisplayName("마지막 주기이면 Optional.empty()를 반환한다")
-    void findNextScheduledAt_lastCycle() {
-        // given
-        final Member member = memberRepository.save(Member.withoutId(Email.from("last@email.com")));
-        final Review review = reviewRepository.save(Review.withoutId(member, ReviewURL.from("url")));
-        final ReviewCycle last = reviewCycleRepository.save(ReviewCycle.withoutId(review, NOW.plusDays(30)));
-
-        // when
-        final Optional<ReviewCycle> result = reviewCycleRepository
-                .findFirstByReview_IdAndScheduledAtGreaterThanOrderByScheduledAtAsc(
-                        review.getId(), last.getScheduledAt());
-
-        // then
-        assertThat(result).isEmpty();
     }
 
     private ReviewCycle saveCycle(final String email, final LocalDateTime scheduledAt) {

--- a/src/test/java/com/recyclestudy/review/service/NotificationHistoryServiceTest.java
+++ b/src/test/java/com/recyclestudy/review/service/NotificationHistoryServiceTest.java
@@ -1,16 +1,12 @@
 package com.recyclestudy.review.service;
 
 import com.recyclestudy.review.domain.NotificationStatus;
-import com.recyclestudy.review.domain.Review;
-import com.recyclestudy.review.domain.ReviewCycle;
 import com.recyclestudy.review.repository.NotificationHistoryRepository;
-import com.recyclestudy.review.repository.ReviewCycleRepository;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,7 +17,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -29,9 +24,6 @@ class NotificationHistoryServiceTest {
 
     @Mock
     NotificationHistoryRepository notificationHistoryRepository;
-
-    @Mock
-    ReviewCycleRepository reviewCycleRepository;
 
     @Mock
     Clock clock;
@@ -58,67 +50,18 @@ class NotificationHistoryServiceTest {
     }
 
     @Test
-    @DisplayName("FAILED 상태로 업데이트하면 deadline과 함께 failCount를 1 증가시킨다")
+    @DisplayName("FAILED 상태로 업데이트하면 배치 쿼리로 failCount를 1 증가시킨다")
     void updateStatus_failed() {
         // given
-        final Long reviewCycleId = 1L;
-        final LocalDateTime scheduledAt = LocalDateTime.of(2026, 1, 1, 10, 0);
-        final LocalDateTime nextScheduledAt = LocalDateTime.of(2026, 1, 2, 10, 0);
-
-        final Review review = mock(Review.class);
-        BDDMockito.given(review.getId()).willReturn(100L);
-
-        final ReviewCycle reviewCycle = mock(ReviewCycle.class);
-        BDDMockito.given(reviewCycle.getReview()).willReturn(review);
-        BDDMockito.given(reviewCycle.getScheduledAt()).willReturn(scheduledAt);
-
+        final List<Long> reviewCycleIds = List.of(1L, 2L);
         BDDMockito.given(clock.instant()).willReturn(Instant.parse("2026-01-01T00:00:00Z"));
         BDDMockito.given(clock.getZone()).willReturn(ZoneId.of("UTC"));
-        final ReviewCycle nextReviewCycle = mock(ReviewCycle.class);
-        BDDMockito.given(nextReviewCycle.getScheduledAt()).willReturn(nextScheduledAt);
-
-        BDDMockito.given(reviewCycleRepository.findById(reviewCycleId))
-                .willReturn(Optional.of(reviewCycle));
-        BDDMockito.given(reviewCycleRepository
-                .findFirstByReview_IdAndScheduledAtGreaterThanOrderByScheduledAtAsc(review.getId(), scheduledAt))
-                .willReturn(Optional.of(nextReviewCycle));
 
         // when
-        notificationHistoryService.updateStatus(List.of(reviewCycleId), NotificationStatus.FAILED);
+        notificationHistoryService.updateStatus(reviewCycleIds, NotificationStatus.FAILED);
 
         // then
-        verify(notificationHistoryRepository).updateStatusWithIncrementFailCount(
-                eq(reviewCycleId), eq(NotificationStatus.FAILED), any(LocalDateTime.class), eq(nextScheduledAt));
-    }
-
-    @Test
-    @DisplayName("마지막 주기이면 deadline을 scheduledAt + 24h로 설정한다")
-    void updateStatus_failed_lastCycle() {
-        // given
-        final Long reviewCycleId = 1L;
-        final LocalDateTime scheduledAt = LocalDateTime.of(2026, 1, 30, 10, 0);
-        final LocalDateTime expectedDeadline = scheduledAt.plusHours(24);
-
-        final Review review = mock(Review.class);
-        BDDMockito.given(review.getId()).willReturn(100L);
-
-        final ReviewCycle reviewCycle = mock(ReviewCycle.class);
-        BDDMockito.given(reviewCycle.getReview()).willReturn(review);
-        BDDMockito.given(reviewCycle.getScheduledAt()).willReturn(scheduledAt);
-
-        BDDMockito.given(clock.instant()).willReturn(Instant.parse("2026-01-30T00:00:00Z"));
-        BDDMockito.given(clock.getZone()).willReturn(ZoneId.of("UTC"));
-        BDDMockito.given(reviewCycleRepository.findById(reviewCycleId))
-                .willReturn(Optional.of(reviewCycle));
-        BDDMockito.given(reviewCycleRepository
-                .findFirstByReview_IdAndScheduledAtGreaterThanOrderByScheduledAtAsc(review.getId(), scheduledAt))
-                .willReturn(Optional.empty());
-
-        // when
-        notificationHistoryService.updateStatus(List.of(reviewCycleId), NotificationStatus.FAILED);
-
-        // then
-        verify(notificationHistoryRepository).updateStatusWithIncrementFailCount(
-                eq(reviewCycleId), eq(NotificationStatus.FAILED), any(LocalDateTime.class), eq(expectedDeadline));
+        verify(notificationHistoryRepository).updateStatusAndIncrementFailCount(
+                eq(reviewCycleIds), eq(NotificationStatus.FAILED), any(LocalDateTime.class));
     }
 }

--- a/src/test/java/com/recyclestudy/review/service/ReviewCycleServiceTest.java
+++ b/src/test/java/com/recyclestudy/review/service/ReviewCycleServiceTest.java
@@ -187,9 +187,9 @@ class ReviewCycleServiceTest {
 
         final Review review = Review.withoutId(member, ReviewURL.from("https://example.com"));
         final NotificationHistory nh1 = NotificationHistory.withoutId(ReviewCycle.withoutId(review, t1),
-                NotificationStatus.PENDING);
+                NotificationStatus.PENDING, t2);
         final NotificationHistory nh2 = NotificationHistory.withoutId(ReviewCycle.withoutId(review, t2),
-                NotificationStatus.PENDING);
+                NotificationStatus.PENDING, t2.plusHours(24));
 
         given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.of(member));
         given(notificationHistoryRepository.findAllByMemberAndStatus(member.getId(), NotificationStatus.PENDING))
@@ -216,11 +216,11 @@ class ReviewCycleServiceTest {
 
         final Review review = Review.withoutId(member, ReviewURL.from("https://example.com"));
         final NotificationHistory nh1 = NotificationHistory.withoutId(ReviewCycle.withoutId(review, t1),
-                NotificationStatus.PENDING);
+                NotificationStatus.PENDING, t1.plusHours(24));
         final NotificationHistory nh2 = NotificationHistory.withoutId(ReviewCycle.withoutId(review, t1),
-                NotificationStatus.PENDING);
+                NotificationStatus.PENDING, t1.plusHours(24));
         final NotificationHistory nh3 = NotificationHistory.withoutId(ReviewCycle.withoutId(review, t1),
-                NotificationStatus.PENDING);
+                NotificationStatus.PENDING, t1.plusHours(24));
 
         given(memberRepository.findByIdentifier(identifier)).willReturn(Optional.of(member));
         given(notificationHistoryRepository.findAllByMemberAndStatus(member.getId(), NotificationStatus.PENDING))

--- a/src/test/java/com/recyclestudy/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/recyclestudy/review/service/ReviewServiceTest.java
@@ -110,10 +110,12 @@ class ReviewServiceTest {
         final ArgumentCaptor<List<NotificationHistory>> captor = ArgumentCaptor.forClass(List.class);
         verify(notificationHistoryRepository).saveAll(captor.capture());
 
+        final LocalDateTime expectedDeadline = now.plusDays(1).plusHours(24);
         assertSoftly(softAssertions -> {
             softAssertions.assertThat(actual.url()).isEqualTo(ReviewURL.from(urlValue));
             softAssertions.assertThat(actual.scheduledAts()).hasSize(1);
             softAssertions.assertThat(captor.getValue()).allMatch(h -> h.getStatus() == NotificationStatus.PENDING);
+            softAssertions.assertThat(captor.getValue()).allMatch(h -> h.getDeadline().equals(expectedDeadline));
         });
 
         verify(memberRepository).findByIdentifier(any(DeviceIdentifier.class));


### PR DESCRIPTION
<!-- PR 템플릿 -->

## 🚀 작업 내용

`NotificationHistory.deadline`을 리뷰 저장 시점(PENDING 생성 시)에 결정하도록 구조를 개선한다.

### `NotificationHistory`
- `deadline` 컬럼에 `nullable = false` 제약 추가
- `withoutId()` 팩토리 메서드에 `deadline` 파라미터 추가
- `validateNotNull()` 검증에 `deadline` 포함

### `ReviewService`
- `savePendingNotificationHistory()` - `IntStream`으로 주기 인덱스를 순회하며 `deadline` 계산
  - i번째 주기 deadline = i+1번째 주기의 `scheduledAt`
  - 마지막 주기 deadline = `scheduledAt + 24시간`
- `LAST_CYCLE_DEADLINE_HOURS` 상수를 `NotificationHistoryService` -> `ReviewService`로 이동

### `NotificationHistoryService`
- `ReviewCycleRepository` 의존성 제거
- `updateToFailed()` 메서드 제거
- 실패 상태 업데이트를 `updateStatusAndIncrementFailCount()` 직접 호출로 단순화

### `NotificationHistoryRepository`
- 메서드명 변경: `updateStatusWithIncrementFailCount()` → `updateStatusAndIncrementFailCount()`
- 파라미터 변경: 단일 ID -> `List<Long> reviewCycleIds` (IN 절 배치 처리)
- `deadline` 파라미터 제거 (실패 전환 시 deadline 변경 불필요)

### `ReviewCycleRepository`
- `findFirstByReview_IdAndScheduledAtGreaterThanOrderByScheduledAtAsc()` 제거 (미사용)

### DB 마이그레이션
1. 다음 주기가 있는 레코드 → `deadline = 다음 주기의 scheduled_at`
2. 마지막 주기 레코드 → `deadline = scheduled_at + INTERVAL 24 HOUR`
3. `deadline` 컬럼을 NOT NULL로 변경

### 테스트
- [X] `NotificationHistoryTest` - deadline 포함 엔티티 생성 검증
- [X] `NotificationHistoryRepositoryTest` - 배치 업데이트 쿼리 검증
- [X] `ReviewCycleRepositoryTest` - 제거된 메서드 테스트 정리
- [X] `NotificationHistoryServiceTest` - 단순화된 updateStatus 흐름 검증
- [X] `ReviewServiceTest` - deadline 계산 로직 검증
- [X] 마이그레이션 스크립트 로컬 DB에서 수동 검증

## 📸 이슈 번호

- close #88 

## ✍ 궁금한 점

- X
