### PR TITLE
db 커넥션 풀 및 jvm 설정 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ USER appuser
 
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-Duser.timezone=UTC", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-Duser.timezone=UTC", "-XX:+UseContainerSupport", "-XX:MaxRAMPercentage=60.0", "-XX:InitialRAMPercentage=60.0", "-XX:MaxMetaspaceSize=150m", "-XX:+ExitOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/app/log/heapdump.hprof", "-jar", "app.jar"]

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -9,6 +9,10 @@ services:
       - .env
     volumes:
       - /app/log:/app/log
+    deploy:
+      resources:
+        limits:
+          memory: 600m
     networks:
       - observability
 
@@ -30,6 +34,10 @@ services:
     ports:
       - "12345:12345" # Alloy UI
       - "4317:4317"   # OTLP gRPC
+    deploy:
+      resources:
+        limits:
+          memory: 150m
     networks:
       - observability
 
@@ -37,6 +45,10 @@ services:
     image: quay.io/prometheus/node-exporter:latest
     container_name: node-exporter
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 30m
     networks:
       - observability
 

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,4 +1,7 @@
 spring:
+  datasource:
+    hikari:
+      leak-detection-threshold: 5000
   jpa:
     properties:
       hibernate:


### PR DESCRIPTION
## 🚀 작업 내용

### 원인 분석
힙 덤프 분석 결과 두 가지 원인을 확인함.

- `-Xmx` 미설정으로 JVM 기본 힙이 약 227MB로 동작 중이었고,
  Spring Boot + OpenTelemetry + AWS SDK 조합에서 부하 시 90%에 도달
- HikariCP `maxLifetime` 기본값(30분)에 의한 커넥션 교체 사이클로
  `ConnectionImpl` 객체가 Finalizer 처리 속도보다 빠르게 누적 (힙 덤프 시점 1,506개 확인)
- 위 두 원인이 복합 작용: GC STW → 커넥션 점유 시간 증가 → pool 고갈 → timeout 47회 발생

### 변경 사항

**Dockerfile**
- `-XX:MaxRAMPercentage=60.0` : 컨테이너 limit(600m) 기준 360MB를 최대 힙으로 사용
- `-XX:InitialRAMPercentage=60.0` : 초기 힙을 최대값과 동일하게 설정해 힙 확장 비용 제거
- `-XX:MaxMetaspaceSize=150m` : NMT 실측값(~94MB) 기반으로 설정, 무제한 확장 방지
- `-XX:+ExitOnOutOfMemoryError` : OOM 시 즉시 종료 후 컨테이너 재시작 유도
- `-XX:+HeapDumpOnOutOfMemoryError` : OOM 발생 시 자동 힙 덤프 생성
- `-XX:HeapDumpPath=/app/log/heapdump.hprof` : 볼륨 마운트 경로에 저장해 재시작 후에도 보존

**docker-compose.yml**
- app: 600m / alloy: 150m / node-exporter: 30m 메모리 제한 설정
- t4g.micro 가용 메모리(909MB) 기준으로 각 컨테이너 배분

**application-prod.yaml**
- `leak-detection-threshold: 5000` 추가
- 5초 이상 반환되지 않는 커넥션 발생 시 스택 트레이스 포함 경고 로그 출력
- HikariCP 추가 튜닝 필요 여부를 판단하기 위한 모니터링 목적

## 📸 이슈 번호
- close #98 

## ✍ 궁금한 점
- 매직 넘버 설정 초기값을 정하는 기준은 어떻게 잡아야 할까?
